### PR TITLE
docs: update validate_integration docs for icon size and shell quoting

### DIFF
--- a/scripts/docs/validate_integration.md
+++ b/scripts/docs/validate_integration.md
@@ -80,7 +80,7 @@ Checks that all mandatory files exist in the integration directory:
 | `__init__.py` | Error | Python package init |
 | `requirements.txt` | Error | Python dependencies |
 | `README.md` | Error | Integration documentation |
-| `icon.png` or `icon.svg` | Error | Integration icon (either format accepted) |
+| `icon.png` or `icon.svg` | Error | Integration icon — must be exactly 512x512 pixels |
 
 ### 3. config.json Validation (`_check_config_json`)
 
@@ -248,7 +248,7 @@ Called by the `validate-integration.yml` workflow (on pull requests) as the **St
 ```yaml
 - name: Structure Check
   if: steps.changed.outputs.dirs != ''
-  run: python scripts/validate_integration.py ${{ steps.changed.outputs.dirs }}
+  run: python scripts/validate_integration.py "${{ steps.changed.outputs.dirs }}"
 ```
 
 The script is also exercised by the `self-test.yml` workflow, which runs it against the test examples in `tests/examples/` as a regression guard whenever `scripts/` or `tests/` change.


### PR DESCRIPTION
## Summary

Updates documentation for the validate_integration script to clarify icon requirements and improve CI configuration examples.

## Motivation and Context

The validate_integration documentation needed clarification on icon size requirements and proper shell quoting in CI workflows to prevent potential issues with directory paths containing spaces.

## Technical Approach

Updated the documentation in two key areas:
1. Enhanced the required files table to specify exact icon dimensions
2. Improved the CI workflow example with proper shell quoting for robustness

## Type of Change

- [x] Documentation update

## Changes

- Specify that integration icons must be exactly 512x512 pixels in the required files table
- Add proper shell quoting to the CI workflow example to handle directory paths with spaces safely