### PR TITLE
docs: add SDK cross-link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Validation tools and CI/CD workflows for Autohive integrations.
 
+> 📖 **Building an integration?** See the [SDK documentation](https://github.com/autohive-ai/integrations-sdk/tree/master/docs/manual) for the tutorial, structure reference, and patterns.
+
 **Requires: Python 3.13+**
 
 ## What's Included


### PR DESCRIPTION
Phase 5 (cross-linking verification) of the documentation unification.

## Problem

The tooling repo README was the only repo README without a link to the SDK docs. The [CONTRIBUTING.md](CONTRIBUTING.md) and [INTEGRATION_CHECKLIST.md](INTEGRATION_CHECKLIST.md) already link to the SDK, but someone landing on the README had no pointer to "how to build an integration."

## Change

Adds a one-line callout at the top of the README linking to the [SDK documentation](https://github.com/autohive-ai/integrations-sdk/tree/master/docs/manual).

## Context

Part of the documentation unification across all 4 repos:

- **Phase 1** — SDK docs rewritten: [integrations-sdk#13](https://github.com/Autohive-AI/integrations-sdk/pull/13) (merged)
- **Phase 2** — Tooling docs slimmed: [integrations-sdk#15](https://github.com/Autohive-AI/integrations-sdk/pull/15), [autohive-integrations-tooling#16](https://github.com/Autohive-AI/autohive-integrations-tooling/pull/16) (merged)
- **Phase 3** — Public integrations cleanup: [autohive-integrations#187](https://github.com/Autohive-AI/autohive-integrations/pull/187) (merged)
- **Phase 4** — Private integrations cleanup: [integrations#100](https://github.com/Autohive-AI/integrations/pull/100)
- **Phase 5** — Cross-linking verification: this PR