### PR TITLE
feat: replace name-folder match check with display_name warning

### DIFF
--- a/INTEGRATION_CHECKLIST.md
+++ b/INTEGRATION_CHECKLIST.md
@@ -56,6 +56,7 @@ The structure check produces warnings (not errors) for these cases:
 |---------|-------------|
 | `Integration.load()` not found | The check looks for the literal string `Integration.load()`. Using `Integration.load(config_path)` triggers this warning — that's expected for multi-file integrations. |
 | Missing `__init__.py` | Optional for modular integrations with an `actions/` subdirectory |
+| Missing top-level `display_name` | Recommended but not required |
 | Missing `display_name` on actions | Recommended but not required |
 | Potentially unused OAuth scopes | Heuristic check — verify manually |
 

--- a/scripts/docs/validate_integration.md
+++ b/scripts/docs/validate_integration.md
@@ -88,11 +88,17 @@ Checks that all mandatory files exist in the integration directory:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `name` | string | Must match folder name (case-insensitive, `-` and `_` normalized) |
+| `name` | string | Integration identifier |
 | `version` | string | Semantic version format (`x.y.z`) |
 | `description` | string | Clear description of the integration |
 | `entry_point` | string | Main Python file (must exist on disk) |
 | `actions` | object | At least one action must be defined |
+
+#### Recommended Fields
+
+| Check | Severity | Description |
+|-------|----------|-------------|
+| `display_name` present and non-empty | Warning | Human-readable name for the integration |
 
 #### Auth Configuration (`_validate_auth_config`)
 

--- a/scripts/validate_integration.py
+++ b/scripts/validate_integration.py
@@ -199,12 +199,9 @@ class IntegrationValidator:
             if field not in self.config:
                 self.add_error(f"config.json missing required field: '{field}'")
 
-        # Check name matches folder
-        if 'name' in self.config:
-            config_name = self.config['name'].lower().replace('_', '-')
-            folder_name = self.name.lower().replace('_', '-')
-            if config_name != folder_name:
-                self.add_warning(f"config.json 'name' ({self.config['name']}) doesn't match folder name ({self.name})")
+        # Check display_name is present
+        if 'display_name' not in self.config:
+            self.add_warning("config.json missing recommended field: 'display_name'")
 
         # Check entry_point exists
         if 'entry_point' in self.config:

--- a/scripts/validate_integration.py
+++ b/scripts/validate_integration.py
@@ -199,8 +199,8 @@ class IntegrationValidator:
             if field not in self.config:
                 self.add_error(f"config.json missing required field: '{field}'")
 
-        # Check display_name is present
-        if 'display_name' not in self.config:
+        # Check display_name is present and non-empty
+        if 'display_name' not in self.config or not self.config['display_name'].strip():
             self.add_warning("config.json missing recommended field: 'display_name'")
 
         # Check entry_point exists


### PR DESCRIPTION
## Changes

1. **Removed** the check that warned when `config.json`'s `name` didn't match the directory name.
2. **Added** a new warning (non-blocking) if `display_name` is not specified in `config.json`.

Closes #20