### PR TITLE
fix: fail build if integration contains local integration.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,16 @@ When `post_comment` is enabled, the action posts a sticky comment on the PR with
 
 ## Versioning
 
-This tooling library's version reflects the maximum supported version of the [Autohive Integrations SDK](https://github.com/autohive-ai/integrations-sdk). For example, tooling version `2.0.0` validates integrations built with SDK versions up to `2.0.0`. When the SDK releases a new version and this tooling adds support for it, the tooling version is bumped to match.
+The **major** version of this tooling matches the [Autohive Integrations SDK](https://github.com/autohive-ai/integrations-sdk) major version it targets. The **minor** and **patch** versions are the tooling's own iteration and do _not_ correspond to SDK releases.
 
-This means the tag you reference in your workflow (e.g. `autohive-ai/autohive-integrations-tooling@2.0.0`) directly tells you which SDK version it supports.
+For example, `2.1.0` means "the second tooling release for SDK v2" — it does not imply an SDK `2.1.0` exists.
+
+| Tooling version | Meaning |
+|-----------------|---------|
+| `2.0.0` | Initial tooling release for SDK v2 |
+| `2.1.0` | New checks or features (still SDK v2) |
+| `2.1.1` | Bug-fix to the tooling (still SDK v2) |
+| `3.0.0` | Tooling targeting SDK v3 |
 
 ## Setup
 

--- a/scripts/validate_integration.py
+++ b/scripts/validate_integration.py
@@ -123,6 +123,10 @@ class IntegrationValidator:
         if not (self.path / '__init__.py').exists() and not has_actions_dir:
             self.add_warning("Missing __init__.py (required for package-style integrations, optional for modular integrations with actions/)")
 
+        # Check for forbidden files
+        if (self.path / 'integration.py').exists():
+            self.add_error("Found 'integration.py' — integrations must not include a local integration.py file")
+
         # Check for icon (png or svg)
         png_path = self.path / 'icon.png'
         svg_path = self.path / 'icon.svg'


### PR DESCRIPTION
## Changes

### 1. Forbid local `integration.py`

Adds a validation error if an integration directory contains an `integration.py` file. This file should not exist locally in any integration — having one will now fail the structure check.

### 2. Fix versioning policy

The previous policy stated that the tooling version mirrors the SDK version 1:1 (e.g. tooling `2.0.0` = SDK `2.0.0`). This created a problem: if we ship a tooling fix or new check, the next logical version would be `2.0.1` — but there is no SDK `2.0.1`, making the version misleading.

Updated the policy so only the **major** version tracks the SDK (tooling `2.x.x` → targets SDK v2). Minor and patch versions are the tooling's own iteration, allowing us to ship independent fixes and features without implying a corresponding SDK release exists.