### PR TITLE
fix: handle renamed/removed directories gracefully in CI

### DIFF
--- a/scripts/check_code.py
+++ b/scripts/check_code.py
@@ -77,9 +77,8 @@ def check_code(dirs: list[str]) -> int:
         print()
 
         if not dir_path.is_dir():
-            print(f"   ❌ Directory not found: {dir_name}")
+            print(f"   ⚠️ Directory not found (renamed or removed?): {dir_name} — skipping")
             print()
-            failed = True
             continue
 
         # Install dependencies

--- a/scripts/get_changed_dirs.py
+++ b/scripts/get_changed_dirs.py
@@ -30,15 +30,17 @@ Examples:
 import argparse
 import subprocess
 import sys
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 
 SKIP_DIRS = frozenset({".github", "scripts", "tests", "template-structure"})
 
 
-def get_changed_dirs(base_ref: str) -> list[str] | None:
-    """Return sorted, deduplicated integration directory names changed since *base_ref*.
+def get_changed_dirs(base_ref: str) -> tuple[list[str], list[str]] | None:
+    """Return integration directory names changed since *base_ref*.
 
-    Returns None if the git command fails.
+    Returns a tuple of (existing_dirs, renamed_dirs) where renamed_dirs are
+    directories that appear in the diff but no longer exist on disk (i.e. the
+    old side of a rename). Returns None if the git command fails.
     """
     result = subprocess.run(
         ["git", "diff", "--name-only", base_ref, "HEAD"],
@@ -57,7 +59,9 @@ def get_changed_dirs(base_ref: str) -> list[str] | None:
         if top_dir not in SKIP_DIRS:
             dirs.add(top_dir)
 
-    return sorted(dirs)
+    existing = sorted(d for d in dirs if Path(d).is_dir())
+    renamed = sorted(d for d in dirs if not Path(d).is_dir())
+    return existing, renamed
 
 
 def main() -> int:
@@ -70,13 +74,21 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    changed = get_changed_dirs(args.base_ref)
-    if changed is None:
+    result = get_changed_dirs(args.base_ref)
+    if result is None:
         print(f"Error: git diff failed for ref '{args.base_ref}'", file=sys.stderr)
         return 2
 
-    if changed:
-        print(" ".join(changed))
+    existing, renamed = result
+
+    if renamed:
+        print(
+            f"⚠️ Detected renamed/removed directories (skipping): {', '.join(renamed)}",
+            file=sys.stderr,
+        )
+
+    if existing:
+        print(" ".join(existing))
 
     return 0
 

--- a/scripts/validate_integration.py
+++ b/scripts/validate_integration.py
@@ -498,8 +498,7 @@ def validate(dirs: list[str]) -> int:
                 if folder_name not in SKIP_FOLDERS:
                     folders.append(folder_path)
             else:
-                print(f"❌ Folder not found: {folder_name}")
-                return 2
+                print(f"⚠️ Folder not found (renamed or removed?): {folder_name} — skipping")
     else:
         folders = get_integration_folders(Path.cwd())
 


### PR DESCRIPTION
## Problem

When an integration folder is renamed (e.g. `Firstaml` → `firstaml`), `git diff --name-only` reports both the old and new directory names. The old name no longer exists on disk, causing `validate_integration.py` to exit with code 2 ("Folder not found") and `check_code.py` to mark the check as failed — even though the new directories pass all checks.

## Solution

- **`get_changed_dirs.py`**: Filter out directories that no longer exist on disk and emit a `⚠️` warning on stderr about renamed/removed dirs
- **`validate_integration.py`**: Warn and skip missing directories instead of returning exit code 2
- **`check_code.py`**: Warn and skip missing directories instead of marking the entire check as failed

Renamed directories now produce a visible warning but no longer block the build.