### PR TITLE
feat: add version bump check with bump-level recommendations

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -151,6 +151,24 @@ jobs:
           fi
           echo "✅ Old fetch pattern with SDK 2.x correctly detected"
 
+      - name: Test check_version_bump.py — good integration passes (no changes vs HEAD)
+        run: python scripts/check_version_bump.py HEAD tests/examples/good-integration
+
+      - name: Test check_version_bump.py — missing version detected for new integration
+        run: |
+          # Create a temp integration with no version in config.json
+          mkdir -p /tmp/test-no-version
+          echo '{"name": "test", "description": "test", "entry_point": "main.py", "actions": {}}' > /tmp/test-no-version/config.json
+          if python scripts/check_version_bump.py HEAD /tmp/test-no-version 2>&1; then
+            echo "❌ Expected version check to fail for integration without version"
+            exit 1
+          fi
+          echo "✅ Missing version correctly detected"
+          rm -rf /tmp/test-no-version
+
+      - name: Test check_version_bump.py — missing directory is skipped (not failed)
+        run: python scripts/check_version_bump.py HEAD nonexistent-directory
+
       - name: Test get_changed_dirs.py — missing argument
         run: |
           if python scripts/get_changed_dirs.py 2>&1; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,7 @@ Your PR will automatically run:
 - **Structure Check** — validates folder structure and config.json
 - **Code Check** — syntax, imports, JSON, lint, format, security, dependency audit
 - **README Check** — verifies the main README.md was updated
+- **Version Check** — verifies config.json version was incremented, recommends bump level
 - **Conventional Commits** — validates PR title format
 
 Results are posted as a sticky PR comment with a summary table and expandable output for each check.

--- a/INTEGRATION_CHECKLIST.md
+++ b/INTEGRATION_CHECKLIST.md
@@ -15,6 +15,7 @@ These checks run automatically on every PR. See `scripts/docs/` for detailed doc
 | Structure | [`validate_integration.py`](scripts/docs/validate_integration.md) | Folder name, required files, config.json schema, `__init__.py` minimality, requirements.txt, tests/, icon, unused scopes |
 | Code quality | [`check_code.py`](scripts/docs/check_code.md) | Syntax, imports, JSON validity, ruff lint, ruff format, bandit security, pip-audit CVEs, config-code sync |
 | README update | [`check_readme.py`](scripts/docs/check_readme.md) | Main repo README.md was updated with the new integration |
+| Version bump | [`check_version_bump.py`](scripts/docs/check_version_bump.md) | config.json version incremented; recommends major/minor/patch based on changes |
 | Conventional commits | `conv-commits.yml` | PR title follows conventional commit format |
 
 ### Running Locally

--- a/LOCAL_DEVELOPMENT.md
+++ b/LOCAL_DEVELOPMENT.md
@@ -117,6 +117,7 @@ DIRS=$(python scripts/get_changed_dirs.py origin/main)
 python scripts/validate_integration.py $DIRS
 python scripts/check_code.py $DIRS
 python scripts/check_readme.py origin/main $DIRS
+python scripts/check_version_bump.py origin/main $DIRS
 ```
 
 ## Typical Iteration Cycle
@@ -142,8 +143,9 @@ The `validate-integration.yml` workflow uses the composite action defined in `ac
 | 2 | `validate_integration.py` | Structure and config validation |
 | 3 | `check_code.py` | Syntax, imports, JSON, lint, format, security, deps, config sync |
 | 4 | `check_readme.py` | Checks that the main README.md was updated for new integrations |
+| 5 | `check_version_bump.py` | Checks that config.json version was incremented, recommends bump level |
 
-If no integration directories changed (only `scripts/`, `tests/`, etc.), steps 2–4 are skipped.
+If no integration directories changed (only `scripts/`, `tests/`, etc.), steps 2–5 are skipped.
 
 Results are posted as a sticky PR comment showing ✅ Passed, ⚠️ Passed with warnings, or ❌ Failed for each check.
 
@@ -171,6 +173,7 @@ Detailed documentation for each validation script — usage, arguments, exit cod
 | [check_imports.md](scripts/docs/check_imports.md) | `check_imports.py` | Understanding how imports are resolved (AST parsing, relative imports, `--verify-names`) |
 | [check_config_sync.md](scripts/docs/check_config_sync.md) | `check_config_sync.py` | Understanding how config.json is cross-validated against code (AST-based action and input detection) |
 | [check_readme.md](scripts/docs/check_readme.md) | `check_readme.py` | Understanding the README update requirement for new integrations |
+| [check_version_bump.md](scripts/docs/check_version_bump.md) | `check_version_bump.py` | Understanding the version bump requirement and bump-level recommendations |
 | [get_changed_dirs.md](scripts/docs/get_changed_dirs.md) | `get_changed_dirs.py` | Understanding how CI detects which integrations to validate |
 
 ### Test fixtures (in `tests/examples/`)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Validation tools and CI/CD workflows for Autohive integrations.
 | `scripts/check_code.py` | Syntax, import, JSON, lint, format, security, dependency, and config sync checks ([docs](scripts/docs/check_code.md)) |
 | `scripts/check_imports.py` | Import availability checker ([docs](scripts/docs/check_imports.md)) |
 | `scripts/check_readme.py` | README update verification ([docs](scripts/docs/check_readme.md)) |
+| `scripts/check_version_bump.py` | Version bump verification with bump-level recommendations ([docs](scripts/docs/check_version_bump.md)) |
 | `scripts/check_config_sync.py` | Config-code sync checker ([docs](scripts/docs/check_config_sync.md)) |
 | `scripts/get_changed_dirs.py` | Changed directory detection ([docs](scripts/docs/get_changed_dirs.md)) |
 | `.github/workflows/validate-integration.yml` | PR validation pipeline |
@@ -45,7 +46,8 @@ flowchart TB
         COND -->|No| VI[validate_integration.py]
         VI --> CC[check_code.py]
         CC --> CR[check_readme.py]
-        CR --> CMT_POST[Post PR comment]
+        CR --> VB[check_version_bump.py]
+        VB --> CMT_POST[Post PR comment]
     end
 
     subgraph wf2["self-test.yml"]
@@ -77,6 +79,7 @@ flowchart TB
 | Structure check | `validate_integration.py` | Folder name, required files, config.json schema, `__init__.py`, requirements.txt, tests/, icon size, unused scopes |
 | Code check | `check_code.py` | pip install, py_compile, check_imports, JSON validity, ruff check, ruff format, bandit, pip-audit, check_config_sync |
 | README check | `check_readme.py` | New integration files added → was README.md also updated? |
+| Version check | `check_version_bump.py` | Version in config.json incremented? Recommends major/minor/patch based on config and code changes |
 
 ## Usage as GitHub Action
 
@@ -126,9 +129,11 @@ jobs:
 | `structure_result` | `success` or `failure` |
 | `code_result` | `success` or `failure` |
 | `readme_result` | `success` or `failure` |
+| `version_result` | `success` or `failure` |
 | `structure_output` | Full output of the structure check |
 | `code_output` | Full output of the code check |
 | `readme_output` | Full output of the README check |
+| `version_output` | Full output of the version check |
 
 ### PR Comment
 

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ outputs:
   readme_result:
     description: "'success' or 'failure'"
     value: ${{ steps.readme.outcome }}
+  version_result:
+    description: "'success' or 'failure'"
+    value: ${{ steps.version.outcome }}
   structure_output:
     description: Full output of the structure check
     value: ${{ steps.structure.outputs.output }}
@@ -45,6 +48,9 @@ outputs:
   readme_output:
     description: Full output of the README check
     value: ${{ steps.readme.outputs.output }}
+  version_output:
+    description: Full output of the version check
+    value: ${{ steps.version.outputs.output }}
 
 runs:
   using: composite
@@ -128,6 +134,24 @@ runs:
         fi
         exit $EXIT_CODE
 
+    - name: Version Check
+      id: version
+      if: steps.detect.outputs.dirs != '' && inputs.base_ref != ''
+      continue-on-error: true
+      shell: bash
+      run: |
+        set +e
+        OUTPUT=$(python ${{ github.action_path }}/scripts/check_version_bump.py "${{ inputs.base_ref }}" ${{ steps.detect.outputs.dirs }} 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        echo 'output<<EOF' >> $GITHUB_OUTPUT
+        echo "$OUTPUT" >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
+        if echo "$OUTPUT" | grep -q "⚠️"; then
+          echo "has_warnings=true" >> $GITHUB_OUTPUT
+        fi
+        exit $EXIT_CODE
+
     - name: Delete stale PR comment
       if: always() && steps.detect.outputs.dirs == '' && inputs.post_comment == 'true'
       uses: marocchino/sticky-pull-request-comment@v2
@@ -153,6 +177,7 @@ runs:
           | Structure | ${{ steps.structure.outcome == 'failure' && '❌ Failed' || (steps.structure.outputs.has_warnings == 'true' && '⚠️ Passed with warnings' || '✅ Passed') }} |
           | Code | ${{ steps.code.outcome == 'failure' && '❌ Failed' || (steps.code.outputs.has_warnings == 'true' && '⚠️ Passed with warnings' || '✅ Passed') }} |
           | README | ${{ steps.readme.outcome == 'failure' && '❌ Failed' || (steps.readme.outputs.has_warnings == 'true' && '⚠️ Passed with warnings' || '✅ Passed') }} |
+          | Version | ${{ steps.version.outcome == 'failure' && '❌ Failed' || (steps.version.outputs.has_warnings == 'true' && '⚠️ Passed with warnings' || '✅ Passed') }} |
 
           <details><summary>${{ steps.structure.outcome == 'failure' && '❌' || (steps.structure.outputs.has_warnings == 'true' && '⚠️' || '✅') }} Structure Check output</summary>
 
@@ -178,7 +203,15 @@ runs:
 
           </details>
 
+          <details><summary>${{ steps.version.outcome == 'failure' && '❌' || (steps.version.outputs.has_warnings == 'true' && '⚠️' || '✅') }} Version Check output</summary>
+
+          ```
+          ${{ steps.version.outputs.output }}
+          ```
+
+          </details>
+
     - name: Fail if any check failed
-      if: always() && (steps.structure.outcome == 'failure' || steps.code.outcome == 'failure' || steps.readme.outcome == 'failure')
+      if: always() && (steps.structure.outcome == 'failure' || steps.code.outcome == 'failure' || steps.readme.outcome == 'failure' || steps.version.outcome == 'failure')
       shell: bash
       run: exit 1

--- a/scripts/check_version_bump.py
+++ b/scripts/check_version_bump.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""
+Version Bump Checker
+
+Requires: Python 3.13+
+
+This script checks that integration version numbers are incremented when
+changes are made. It compares the current config.json version against the
+base ref to detect missing or incorrect version bumps, and recommends the
+appropriate bump level (major, minor, patch) based on what changed.
+
+Heuristics for recommended bump level:
+    major - Auth config changed, actions removed, entry_point changed
+    minor - New actions added, new config fields added
+    patch - Only code, tests, requirements, or docs changed
+
+Exit codes:
+    0 - Version check passed
+    1 - Version bump missing or not incremented
+    2 - An error occurred (invalid git ref)
+
+Usage:
+    python scripts/check_version_bump.py <base_ref> <dir> [dir ...]
+
+Examples:
+    python scripts/check_version_bump.py origin/master my-integration
+    python scripts/check_version_bump.py origin/master integration-a integration-b
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def parse_version(version_str: str) -> tuple[int, ...] | None:
+    """Parse a semver string into a tuple of ints. Returns None on failure."""
+    try:
+        parts = tuple(int(p) for p in version_str.split("."))
+        if len(parts) != 3:
+            return None
+        return parts
+    except (ValueError, AttributeError):
+        return None
+
+
+def get_base_config(base_ref: str, dir_name: str) -> dict | None:
+    """Retrieve config.json from the base ref via git show.
+
+    Returns None if the file doesn't exist on the base ref (new integration).
+    """
+    result = subprocess.run(
+        ["git", "show", f"{base_ref}:{dir_name}/config.json"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def get_changed_files(base_ref: str, dir_name: str) -> list[str] | None:
+    """Return list of changed files within a directory relative to base_ref."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", base_ref, "HEAD", "--", f"{dir_name}/"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return [f for f in result.stdout.splitlines() if f.strip()]
+
+
+def get_diff_stats(base_ref: str, dir_name: str) -> dict | None:
+    """Analyse the code diff and return signals for bump classification.
+
+    Returns a dict with keys:
+        py_files_added   - number of new .py files (excluding tests)
+        py_files_deleted - number of deleted .py files (excluding tests)
+        classes_added    - count of added `class …:` lines
+        classes_removed  - count of removed `class …:` lines
+        funcs_added      - count of added `def …(` lines
+        funcs_removed    - count of removed `def …(` lines
+        only_tests_docs  - True if every changed file is in tests/, README, or docs
+    Returns None on git error.
+    """
+    # --- file-level stats (added / deleted) ---
+    for diff_filter, key_suffix in [("A", "added"), ("D", "deleted")]:
+        result = subprocess.run(
+            [
+                "git", "diff", "--name-only", f"--diff-filter={diff_filter}",
+                base_ref, "HEAD", "--", f"{dir_name}/"
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return None
+        files = [f for f in result.stdout.splitlines() if f.strip()]
+        py_files = [
+            f for f in files
+            if f.endswith(".py") and "/tests/" not in f and not f.endswith("test_.py")
+        ]
+        if key_suffix == "added":
+            py_files_added = len(py_files)
+        else:
+            py_files_deleted = len(py_files)
+
+    # --- line-level stats from unified diff of .py files ---
+    result = subprocess.run(
+        ["git", "diff", "-U0", base_ref, "HEAD", "--", f"{dir_name}/*.py", f"{dir_name}/**/*.py"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+
+    func_pattern = re.compile(r"^\s*def\s+\w+\s*\(")
+    class_pattern = re.compile(r"^\s*class\s+\w+")
+
+    funcs_added = funcs_removed = 0
+    classes_added = classes_removed = 0
+
+    for line in result.stdout.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            content = line[1:]
+            if func_pattern.match(content):
+                funcs_added += 1
+            if class_pattern.match(content):
+                classes_added += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            content = line[1:]
+            if func_pattern.match(content):
+                funcs_removed += 1
+            if class_pattern.match(content):
+                classes_removed += 1
+
+    # --- check if only tests / docs changed ---
+    all_changed = get_changed_files(base_ref, dir_name) or []
+    non_test_doc = [
+        f for f in all_changed
+        if not (
+            "/tests/" in f
+            or f.endswith("README.md")
+            or f.endswith(".md")
+            or f.endswith("requirements.txt")
+        )
+    ]
+    # config.json is handled separately so exclude it here
+    non_test_doc = [f for f in non_test_doc if not f.endswith("config.json")]
+    only_tests_docs = len(non_test_doc) == 0
+
+    return {
+        "py_files_added": py_files_added,
+        "py_files_deleted": py_files_deleted,
+        "classes_added": classes_added,
+        "classes_removed": classes_removed,
+        "funcs_added": funcs_added,
+        "funcs_removed": funcs_removed,
+        "only_tests_docs": only_tests_docs,
+    }
+
+
+def recommend_bump(
+    base_config: dict, current_config: dict, changed_files: list[str], dir_name: str,
+    *, base_ref: str = "",
+) -> str:
+    """Recommend major, minor, or patch based on what changed.
+
+    Heuristics (checked in order, first match wins):
+
+    Config-level signals:
+        major - auth changed, actions removed, entry_point changed
+        minor - new actions added, action schemas changed
+
+    Code-level signals (from git diff):
+        major - .py files deleted, classes/functions removed
+        minor - new .py files added, new classes/functions added
+
+    Fallback:
+        patch - everything else (tests, docs, requirements, small edits)
+    """
+    # --- Config-level: Major signals ---
+    base_auth = base_config.get("auth")
+    curr_auth = current_config.get("auth")
+    if base_auth != curr_auth:
+        return "major"
+
+    if base_config.get("entry_point") != current_config.get("entry_point"):
+        return "major"
+
+    base_actions = set(base_config.get("actions", {}).keys())
+    curr_actions = set(current_config.get("actions", {}).keys())
+    removed_actions = base_actions - curr_actions
+    if removed_actions:
+        return "major"
+
+    # --- Config-level: Minor signals ---
+    new_actions = curr_actions - base_actions
+    if new_actions:
+        return "minor"
+
+    # Check if existing action schemas changed (new fields, changed descriptions)
+    for action_name in base_actions & curr_actions:
+        base_action = base_config["actions"][action_name]
+        curr_action = current_config["actions"][action_name]
+        if base_action != curr_action:
+            return "minor"
+
+    # --- Code-level signals ---
+    if base_ref:
+        stats = get_diff_stats(base_ref, dir_name)
+        if stats:
+            # Major: source files or public symbols removed
+            if stats["py_files_deleted"] > 0:
+                return "major"
+            if stats["classes_removed"] > 0 or stats["funcs_removed"] > 0:
+                return "major"
+
+            # Minor: new source files or public symbols added
+            if stats["py_files_added"] > 0:
+                return "minor"
+            if stats["classes_added"] > 0 or stats["funcs_added"] > 0:
+                return "minor"
+
+    # --- Default to patch ---
+    return "patch"
+
+
+def check_version_bump(base_ref: str, dirs: list[str]) -> int:
+    """Check that versions are bumped for changed integrations.
+
+    Returns 0 on success, 1 on failure, 2 on git errors.
+    """
+    failed = False
+
+    for d in dirs:
+        dir_path = Path(d)
+        if not dir_path.is_dir():
+            print(f"⚠️ Directory not found (renamed or removed?): {d} — skipping")
+            continue
+
+        config_path = dir_path / "config.json"
+        if not config_path.exists():
+            print(f"⚠️ No config.json in {d} — skipping version check")
+            continue
+
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                current_config = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"❌ Could not read {d}/config.json: {e}")
+            failed = True
+            continue
+
+        current_version_str = current_config.get("version")
+        current_version = parse_version(current_version_str) if current_version_str else None
+
+        # New integration — just check that a valid version exists
+        base_config = get_base_config(base_ref, d)
+        if base_config is None:
+            if current_version is None:
+                print(f"❌ {d}: New integration must have a valid semver 'version' in config.json (e.g. \"1.0.0\")")
+                failed = True
+            else:
+                print(f"✅ {d}: New integration with version {current_version_str}")
+            continue
+
+        # Existing integration — check for version bump
+        base_version_str = base_config.get("version")
+        base_version = parse_version(base_version_str) if base_version_str else None
+
+        if current_version is None:
+            print(f"❌ {d}: config.json must have a valid semver 'version' (e.g. \"1.0.0\")")
+            failed = True
+            continue
+
+        if base_version is None:
+            # Base had no valid version — any valid version now is fine
+            print(f"✅ {d}: Version set to {current_version_str}")
+            continue
+
+        changed_files = get_changed_files(base_ref, d)
+        if changed_files is None:
+            print(f"Error: git diff failed for ref '{base_ref}'")
+            return 2
+
+        if not changed_files:
+            # No changes in this dir — nothing to check
+            continue
+
+        # Only config.json changed with no version diff is still a problem,
+        # but if nothing meaningful changed we skip
+        if current_version_str == base_version_str:
+            recommendation = recommend_bump(base_config, current_config, changed_files, d, base_ref=base_ref)
+            print(f"❌ {d}: Version not incremented ({base_version_str} → {current_version_str})")
+            print()
+
+            base_major, base_minor, base_patch = base_version
+            if recommendation == "major":
+                suggested = f"{base_major + 1}.0.0"
+                reason = "breaking changes detected (auth, removed actions, entry_point, or code removed)"
+            elif recommendation == "minor":
+                suggested = f"{base_major}.{base_minor + 1}.0"
+                reason = "new features detected (new actions, schema changes, or new functions/classes)"
+            else:
+                suggested = f"{base_major}.{base_minor}.{base_patch + 1}"
+                reason = "code changes detected (bug fixes, docs, or dependency updates)"
+
+            print(f"   Recommended: {base_version_str} → {suggested} ({recommendation} bump)")
+            print(f"   Reason: {reason}")
+            print()
+            print(f"   Changed files:")
+            for f in changed_files:
+                print(f"     - {f}")
+            print()
+            failed = True
+            continue
+
+        if current_version <= base_version:
+            print(f"❌ {d}: Version must be greater than {base_version_str} (found {current_version_str})")
+            failed = True
+            continue
+
+        # Version was bumped — show what happened and recommend if the bump level seems off
+        recommendation = recommend_bump(base_config, current_config, changed_files, d, base_ref=base_ref)
+        actual_bump = _detect_bump_level(base_version, current_version)
+
+        bump_note = ""
+        if _bump_rank(actual_bump) < _bump_rank(recommendation):
+            bump_note = f" (⚠️ consider a {recommendation} bump — {_bump_reason(recommendation)})"
+
+        print(f"✅ {d}: {base_version_str} → {current_version_str} ({actual_bump} bump){bump_note}")
+
+    print()
+    print("========================================")
+    if failed:
+        print("❌ VERSION CHECK FAILED")
+        print("========================================")
+        return 1
+    print("✅ VERSION CHECK PASSED")
+    print("========================================")
+    return 0
+
+
+def _detect_bump_level(
+    base: tuple[int, ...], current: tuple[int, ...]
+) -> str:
+    """Detect whether the version change was major, minor, or patch."""
+    if current[0] > base[0]:
+        return "major"
+    if current[1] > base[1]:
+        return "minor"
+    return "patch"
+
+
+def _bump_rank(level: str) -> int:
+    """Return a numeric rank for bump levels (higher = more significant)."""
+    return {"patch": 0, "minor": 1, "major": 2}.get(level, 0)
+
+
+def _bump_reason(level: str) -> str:
+    """Return a short reason string for a recommended bump level."""
+    return {
+        "major": "breaking changes detected (removed code, auth, or actions)",
+        "minor": "new features detected (new functions, classes, or actions)",
+        "patch": "code changes detected",
+    }.get(level, "")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check that integration versions are bumped when changes are made.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Exit codes:
+  0  Version check passed
+  1  Version bump missing or not incremented
+  2  An error occurred (invalid git ref)
+
+Examples:
+  %(prog)s origin/master my-integration
+  %(prog)s origin/master integration-a integration-b
+""",
+    )
+    parser.add_argument("base_ref", help="Git ref to diff against (e.g., origin/master)")
+    parser.add_argument("dirs", nargs="+", metavar="dir", help="Integration directories to check")
+    args = parser.parse_args()
+    return check_version_bump(args.base_ref, args.dirs)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/docs/check_version_bump.md
+++ b/scripts/docs/check_version_bump.md
@@ -1,0 +1,214 @@
+# check_version_bump.py
+
+Verifies that integration versions are incremented when changes are made, and recommends the appropriate bump level.
+
+## Overview
+
+When an integration is modified in a pull request, its `version` field in `config.json` must be incremented. This script compares the current version against the base ref to detect missing bumps, and uses heuristics based on config and code changes to recommend major, minor, or patch.
+
+For new integrations (no `config.json` on the base ref), it simply checks that a valid semver version exists.
+
+This check only makes sense in the context of a pull request, where there is a clear base ref to compare against.
+
+## Usage
+
+```bash
+python scripts/check_version_bump.py <base_ref> <dir> [dir ...]
+```
+
+### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `base_ref` | Yes | Git ref to diff against (e.g., `origin/master`) |
+| `dir` | Yes (one or more) | Integration directories to check |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0`  | All versions are correctly bumped (or no changes detected) |
+| `1`  | Version bump missing or version not incremented |
+| `2`  | An error occurred (invalid git ref, missing arguments) |
+
+### Examples
+
+```bash
+# Check a single integration against master
+python scripts/check_version_bump.py origin/master my-integration
+
+# Check multiple integrations
+python scripts/check_version_bump.py origin/master integration-a integration-b
+
+# Combine with get_changed_dirs.py
+python scripts/check_version_bump.py origin/master $(python scripts/get_changed_dirs.py origin/master)
+```
+
+## How It Works
+
+```mermaid
+flowchart TD
+    A{For each directory} --> B{Directory exists?}
+    B -->|No| W1[Warn and skip]
+    W1 --> A
+    B -->|Yes| C{config.json exists?}
+    C -->|No| W2[Warn and skip]
+    W2 --> A
+    C -->|Yes| D[Read current version]
+    D --> E{Base config exists?}
+    E -->|No — new integration| F{Valid semver version?}
+    F -->|Yes| G[Pass]
+    F -->|No| H[Fail]
+    E -->|Yes — existing integration| I[Compare versions]
+    I --> J{Files changed?}
+    J -->|No| G
+    J -->|Yes| K{Version incremented?}
+    K -->|Same| L[Fail + recommend bump level]
+    K -->|Decreased| M[Fail]
+    K -->|Incremented| N{Bump level sufficient?}
+    N -->|Yes| G
+    N -->|Undershoot| O[Pass + warn about recommended level]
+    A --> P{Any failures?}
+    P -->|Yes| Q[Exit 1]
+    P -->|No| R[Exit 0]
+```
+
+### Step-by-Step
+
+1. For each given integration directory:
+   a. Skip with a warning if the directory or `config.json` doesn't exist
+   b. Read the current `version` from `config.json`
+   c. Retrieve the base version via `git show <base_ref>:<dir>/config.json`
+   d. If no base config exists → new integration; just verify a valid semver version is present
+   e. If files changed but version is unchanged → fail with a recommended bump level
+   f. If version decreased or stayed the same → fail
+   g. If version incremented but the bump level is lower than recommended → pass with a warning
+2. Exit with code 1 if any failures, 0 otherwise
+
+### Key Git Commands
+
+| Command | Purpose |
+|---------|---------|
+| `git show <base>:<dir>/config.json` | Retrieve the config.json from the base ref |
+| `git diff --name-only <base> HEAD -- <dir>/` | List changed files within the directory |
+| `git diff --name-only --diff-filter=A <base> HEAD -- <dir>/` | Find newly added files |
+| `git diff --name-only --diff-filter=D <base> HEAD -- <dir>/` | Find deleted files |
+| `git diff -U0 <base> HEAD -- <dir>/*.py <dir>/**/*.py` | Get line-level diff of Python files for symbol analysis |
+
+## Bump Recommendation Heuristic
+
+The script recommends a bump level by inspecting both config.json changes and code diffs. Checks are evaluated in order; the first match wins.
+
+### Config-level signals
+
+| Signal | Recommended Bump |
+|--------|-----------------|
+| `auth` object changed (type, scopes, fields) | **major** |
+| `entry_point` changed | **major** |
+| Actions removed from `actions` | **major** |
+| New actions added to `actions` | **minor** |
+| Existing action schemas changed (description, input_schema, etc.) | **minor** |
+
+### Code-level signals (from `git diff`)
+
+| Signal | Recommended Bump |
+|--------|-----------------|
+| `.py` source files deleted (excluding tests) | **major** |
+| `class` or `def` definitions removed | **major** |
+| New `.py` source files added (excluding tests) | **minor** |
+| New `class` or `def` definitions added | **minor** |
+
+### Fallback
+
+If none of the above signals match, the recommendation defaults to **patch** (bug fixes, docs, dependency updates, test changes).
+
+The recommendation is advisory — bumping at a lower level than recommended produces a ⚠️ warning but does not fail the check. Only a missing or non-incremented version fails.
+
+## Output Format
+
+### When version is not bumped:
+
+```
+❌ my-integration: Version not incremented (1.0.0 → 1.0.0)
+
+   Recommended: 1.0.0 → 1.1.0 (minor bump)
+   Reason: new features detected (new actions, schema changes, or new functions/classes)
+
+   Changed files:
+     - my-integration/my_integration.py
+     - my-integration/actions/new_action.py
+     - my-integration/config.json
+
+========================================
+❌ VERSION CHECK FAILED
+========================================
+```
+
+### When version is bumped correctly:
+
+```
+✅ my-integration: 1.0.0 → 1.0.1 (patch bump)
+
+========================================
+✅ VERSION CHECK PASSED
+========================================
+```
+
+### When version is bumped but undershooting:
+
+```
+✅ my-integration: 1.0.0 → 1.0.1 (patch bump) (⚠️ consider a minor bump — new features detected (new functions, classes, or actions))
+
+========================================
+✅ VERSION CHECK PASSED
+========================================
+```
+
+### New integration with valid version:
+
+```
+✅ my-integration: New integration with version 1.0.0
+
+========================================
+✅ VERSION CHECK PASSED
+========================================
+```
+
+### New integration missing version:
+
+```
+❌ my-integration: New integration must have a valid semver 'version' in config.json (e.g. "1.0.0")
+
+========================================
+❌ VERSION CHECK FAILED
+========================================
+```
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| New integration with valid semver version | ✅ Passes |
+| New integration without version field | ❌ Fails |
+| Files changed and version incremented | ✅ Passes |
+| Files changed but version unchanged | ❌ Fails with recommendation |
+| Version decreased | ❌ Fails |
+| Bump level lower than recommended | ✅ Passes with ⚠️ warning |
+| Only test/doc files changed, version unchanged | ❌ Fails (patch bump recommended) |
+| No files changed in directory | ✅ Passes (nothing to check) |
+| Directory doesn't exist on disk | ⚠️ Skipped with warning |
+| No `config.json` in directory | ⚠️ Skipped with warning |
+| Base ref has no valid version | ✅ Passes (any valid version is accepted) |
+| No arguments provided | Exits with code 2 (usage error) |
+
+## Integration with CI
+
+Called by the composite action in `action.yml`, **only during pull requests** when `base_ref` is provided:
+
+```yaml
+- name: Version Check
+  if: steps.detect.outputs.dirs != '' && inputs.base_ref != ''
+  run: python scripts/check_version_bump.py "${{ inputs.base_ref }}" ${{ steps.detect.outputs.dirs }}
+```
+
+This check is skipped when `base_ref` is not provided (e.g., when directories are specified manually without a base ref) since there is no base version to compare against.


### PR DESCRIPTION
## What

New CI check that enforces version bumps in `config.json` when an integration is modified, and **recommends the appropriate bump level** (major/minor/patch) based on what actually changed.

## Why

Previously there was no enforcement around versioning — contributors could make breaking changes without touching the version, making it hard to track what changed across releases. This closes that gap with an automated check that both enforces and guides.

## How it works

### Enforcement (hard fail)
- **Existing integrations**: version must be incremented when files change
- **New integrations**: must have a valid semver version in `config.json`
- Version going backwards → fail

### Recommendations (advisory)
The script inspects both **config.json diffs** and **code diffs** to recommend the right bump level:

| Signal | Recommended bump |
|--------|-----------------|
| Auth config changed | **major** |
| Actions removed | **major** |
| Entry point changed | **major** |
| `.py` files or classes/functions deleted | **major** |
| New actions added | **minor** |
| Action schemas changed | **minor** |
| New `.py` files or classes/functions added | **minor** |
| Everything else (bug fixes, docs, deps) | **patch** |

If someone bumps at a lower level than recommended, the check **passes with a ⚠️ warning** — it doesn't block, just nudges.

### Example output

```
❌ my-integration: Version not incremented (1.0.0 → 1.0.0)

   Recommended: 1.0.0 → 1.1.0 (minor bump)
   Reason: new features detected (new actions, schema changes, or new functions/classes)

   Changed files:
     - my-integration/my_integration.py
     - my-integration/actions/new_action.py
```

## Changes

| File | Change |
|------|--------|
| `scripts/check_version_bump.py` | New script — version enforcement + bump recommendation heuristics |
| `scripts/docs/check_version_bump.md` | Full script documentation (usage, flowchart, heuristics, edge cases) |
| `action.yml` | New Version Check step, output, PR comment row + details, fail gate |
| `.github/workflows/self-test.yml` | 3 regression tests (pass, missing version fails, missing dir skips) |
| `README.md` | File table, CI diagram, checks table, outputs table |
| `CONTRIBUTING.md` | CI checks list |
| `INTEGRATION_CHECKLIST.md` | CI checks summary table |
| `LOCAL_DEVELOPMENT.md` | Local workflow, CI steps table, documentation map |

## Testing

```bash
# No changes vs HEAD → passes
python scripts/check_version_bump.py HEAD tests/examples/good-integration

# Unchanged version with code changes → fails with recommendation
python scripts/check_version_bump.py HEAD~5 tests/examples/good-integration

# Missing directory → warns and skips (exit 0)
python scripts/check_version_bump.py HEAD nonexistent-directory
```