### PR TITLE
feat: add pytest unit test step to CI pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ Validation tools and CI/CD workflows for Autohive integrations.
 | `scripts/check_readme.py` | README update verification ([docs](scripts/docs/check_readme.md)) |
 | `scripts/check_version_bump.py` | Version bump verification with bump-level recommendations ([docs](scripts/docs/check_version_bump.md)) |
 | `scripts/check_config_sync.py` | Config-code sync checker ([docs](scripts/docs/check_config_sync.md)) |
+| `scripts/run_tests.py` | Unit test runner with coverage ([docs](#running-unit-tests)) |
 | `scripts/get_changed_dirs.py` | Changed directory detection ([docs](scripts/docs/get_changed_dirs.md)) |
 | `.github/workflows/validate-integration.yml` | PR validation pipeline |
 | `.github/workflows/self-test.yml` | Regression guard for tooling scripts |
 | `.github/workflows/conv-commits.yml` | Conventional commit enforcement |
-| `requirements-dev.txt` | Dev tool dependencies (ruff, bandit, pip-audit) |
+| `requirements-dev.txt` | Dev tool dependencies (ruff, bandit, pip-audit, pytest, pytest-asyncio, pytest-cov) |
 | `ruff.toml` | Ruff linter and formatter configuration |
 | `CONTRIBUTING.md` | Contributor guide |
 | `LOCAL_DEVELOPMENT.md` | Local development workflow and documentation map |
@@ -45,7 +46,8 @@ flowchart TB
         COND -->|Yes| SKIP[Skip all checks]
         COND -->|No| VI[validate_integration.py]
         VI --> CC[check_code.py]
-        CC --> CR[check_readme.py]
+        CC --> RT[run_tests.py]
+        RT --> CR[check_readme.py]
         CR --> VB[check_version_bump.py]
         VB --> CMT_POST[Post PR comment]
     end
@@ -78,6 +80,7 @@ flowchart TB
 | Detect changes | `get_changed_dirs.py` | `git diff` → extract top-level dirs, filter out `.github`, `scripts`, `tests` |
 | Structure check | `validate_integration.py` | Folder name, required files, config.json schema, `__init__.py`, requirements.txt, tests/, icon size, unused scopes |
 | Code check | `check_code.py` | pip install, py_compile, check_imports, JSON validity, ruff check, ruff format, bandit, pip-audit, check_config_sync |
+| Tests | `run_tests.py` | Discovers and runs `test_*_unit.py` files with pytest, reports coverage. Warns (does not fail) if no unit tests exist |
 | README check | `check_readme.py` | New integration files added → was README.md also updated? |
 | Version check | `check_version_bump.py` | Version in config.json incremented? Recommends major/minor/patch based on config and code changes |
 
@@ -128,10 +131,12 @@ jobs:
 | `directories` | Space-separated list of validated directories |
 | `structure_result` | `success` or `failure` |
 | `code_result` | `success` or `failure` |
+| `tests_result` | `success` or `failure` |
 | `readme_result` | `success` or `failure` |
 | `version_result` | `success` or `failure` |
 | `structure_output` | Full output of the structure check |
 | `code_output` | Full output of the code check |
+| `tests_output` | Full output of the test runner |
 | `readme_output` | Full output of the README check |
 | `version_output` | Full output of the version check |
 
@@ -177,6 +182,23 @@ python scripts/check_imports.py my-integration/main.py
 # Validate all integrations (auto-discovers at repo root)
 python scripts/validate_integration.py
 ```
+
+### Running unit tests
+
+The test runner discovers `test_*_unit.py` files and runs them with pytest and coverage:
+
+```bash
+# Run unit tests for specific integrations
+python scripts/run_tests.py my-integration
+
+# Run unit tests for multiple integrations
+python scripts/run_tests.py hackernews bitly notion
+
+# Run unit tests for all integrations (auto-discovers)
+python scripts/run_tests.py
+```
+
+Integrations without `test_*_unit.py` files are skipped with a warning. The test infrastructure (`pyproject.toml`, `conftest.py`, `requirements-test.txt`) lives in the integrations repo — see its `CONTRIBUTING.md` for how to write and run tests locally.
 
 ## Integration Requirements
 

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,9 @@ outputs:
   version_result:
     description: "'success' or 'failure'"
     value: ${{ steps.version.outcome }}
+  tests_result:
+    description: "'success' or 'failure'"
+    value: ${{ steps.tests.outcome }}
   structure_output:
     description: Full output of the structure check
     value: ${{ steps.structure.outputs.output }}
@@ -51,6 +54,9 @@ outputs:
   version_output:
     description: Full output of the version check
     value: ${{ steps.version.outputs.output }}
+  tests_output:
+    description: Full output of the test runner
+    value: ${{ steps.tests.outputs.output }}
 
 runs:
   using: composite
@@ -106,6 +112,24 @@ runs:
       run: |
         set +e
         OUTPUT=$(python ${{ github.action_path }}/scripts/check_code.py ${{ steps.detect.outputs.dirs }} 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+        echo 'output<<EOF' >> $GITHUB_OUTPUT
+        echo "$OUTPUT" >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
+        if echo "$OUTPUT" | grep -q "⚠️"; then
+          echo "has_warnings=true" >> $GITHUB_OUTPUT
+        fi
+        exit $EXIT_CODE
+
+    - name: Tests
+      id: tests
+      if: steps.detect.outputs.dirs != ''
+      continue-on-error: true
+      shell: bash
+      run: |
+        set +e
+        OUTPUT=$(python ${{ github.action_path }}/scripts/run_tests.py ${{ steps.detect.outputs.dirs }} 2>&1)
         EXIT_CODE=$?
         echo "$OUTPUT"
         echo 'output<<EOF' >> $GITHUB_OUTPUT
@@ -176,6 +200,7 @@ runs:
           |-------|--------|
           | Structure | ${{ steps.structure.outcome == 'failure' && '❌ Failed' || (steps.structure.outputs.has_warnings == 'true' && '⚠️ Passed with warnings' || '✅ Passed') }} |
           | Code | ${{ steps.code.outcome == 'failure' && '❌ Failed' || (steps.code.outputs.has_warnings == 'true' && '⚠️ Passed with warnings' || '✅ Passed') }} |
+          | Tests | ${{ steps.tests.outcome == 'failure' && '❌ Failed' || (steps.tests.outputs.has_warnings == 'true' && '⚠️ Passed with warnings' || '✅ Passed') }} |
           | README | ${{ steps.readme.outcome == 'failure' && '❌ Failed' || (steps.readme.outputs.has_warnings == 'true' && '⚠️ Passed with warnings' || '✅ Passed') }} |
           | Version | ${{ steps.version.outcome == 'failure' && '❌ Failed' || (steps.version.outputs.has_warnings == 'true' && '⚠️ Passed with warnings' || '✅ Passed') }} |
 
@@ -191,6 +216,14 @@ runs:
 
           ```
           ${{ steps.code.outputs.output }}
+          ```
+
+          </details>
+
+          <details><summary>${{ steps.tests.outcome == 'failure' && '❌' || (steps.tests.outputs.has_warnings == 'true' && '⚠️' || '✅') }} Tests output</summary>
+
+          ```
+          ${{ steps.tests.outputs.output }}
           ```
 
           </details>
@@ -212,6 +245,6 @@ runs:
           </details>
 
     - name: Fail if any check failed
-      if: always() && (steps.structure.outcome == 'failure' || steps.code.outcome == 'failure' || steps.readme.outcome == 'failure' || steps.version.outcome == 'failure')
+      if: always() && (steps.structure.outcome == 'failure' || steps.code.outcome == 'failure' || steps.tests.outcome == 'failure' || steps.readme.outcome == 'failure' || steps.version.outcome == 'failure')
       shell: bash
       run: exit 1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,7 @@
 ruff
 bandit
 pip-audit
+pytest>=9.0
+pytest-asyncio>=0.23
+pytest-cov>=4.0
+autohive-integrations-sdk

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Integration Test Runner
+
+Runs pytest unit tests for integration directories that have test_*_unit.py files.
+
+Usage:
+    python scripts/run_tests.py [dir ...]
+
+    If no directories specified, scans all integration folders.
+
+Exit codes:
+    0 - All tests passed (or no tests found)
+    1 - One or more test failures
+    2 - An error occurred
+
+Examples:
+    python scripts/run_tests.py hackernews
+    python scripts/run_tests.py hackernews bitly notion
+    python scripts/run_tests.py
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+# Fix Windows console encoding for unicode characters
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8")
+
+SKIP_FOLDERS = {
+    ".github",
+    ".git",
+    "scripts",
+    "tests",
+    "template-structure",
+    "__pycache__",
+    ".vscode",
+    ".idea",
+    "node_modules",
+    ".venv",
+    ".ruff_cache",
+    ".pytest_cache",
+    "tools",
+}
+
+
+def find_unit_test_files(integration_dir: Path) -> list[Path]:
+    """Find all test_*_unit.py files in an integration's tests/ directory."""
+    tests_dir = integration_dir / "tests"
+    if not tests_dir.is_dir():
+        return []
+    return sorted(tests_dir.glob("test_*_unit.py"))
+
+
+def get_integration_dirs(args: list[str]) -> list[Path]:
+    """Resolve integration directories from CLI args or auto-detect."""
+    if args:
+        dirs = []
+        for name in args:
+            p = Path(name)
+            if p.is_dir():
+                dirs.append(p)
+            else:
+                print(f"❌ Directory not found: {name}")
+                sys.exit(2)
+        return dirs
+
+    # Auto-detect: all subdirectories with a config.json
+    return sorted(
+        p
+        for p in Path(".").iterdir()
+        if p.is_dir() and p.name not in SKIP_FOLDERS and (p / "config.json").exists()
+    )
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    dirs = get_integration_dirs(args)
+
+    if not dirs:
+        print("⚠️  No integration directories found")
+        return 0
+
+    # Collect which integrations have unit tests
+    testable = []
+    skipped = []
+    for d in dirs:
+        test_files = find_unit_test_files(d)
+        if test_files:
+            testable.append((d, test_files))
+        else:
+            skipped.append(d)
+
+    if skipped:
+        print(f"⚠️  No unit tests (test_*_unit.py) found in: {', '.join(d.name for d in skipped)}")
+
+    if not testable:
+        print("⚠️  No unit tests to run")
+        return 0
+
+    # Build pytest command
+    test_file_args = []
+    cov_args = []
+    for d, files in testable:
+        cov_args.extend(["--cov", str(d)])
+        for f in files:
+            test_file_args.append(str(f))
+
+    cmd = [
+        sys.executable, "-m", "pytest",
+        "--import-mode=importlib",
+        "-m", "unit",
+        "-v",
+        "--tb=short",
+        "--no-header",
+        *cov_args,
+        "--cov-report=term-missing:skip-covered",
+        *test_file_args,
+    ]
+
+    print(f"🧪 Running unit tests for: {', '.join(d.name for d, _ in testable)}")
+    print()
+
+    result = subprocess.run(cmd)
+
+    print()
+    if result.returncode == 0:
+        print(f"✅ Tests passed for {len(testable)} integration(s)")
+    else:
+        print(f"❌ Tests failed (exit code {result.returncode})")
+
+    return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds automated unit test execution as a new CI check in the validation pipeline. This runs alongside the existing structure, code, README, and version checks.

## Changes

### `scripts/run_tests.py` (new)
- Discovers `test_*_unit.py` files in changed integration directories
- Runs pytest with coverage reporting (`-v`, `--cov`, `--cov-report=term-missing:skip-covered`)
- Integrations without unit tests get `⚠️` warning, not a failure
- Exits 0 when no tests exist — safe for integrations that haven't added tests yet

### `action.yml`
- New **Tests** step (id: `tests`) between Code and README checks
- `continue-on-error: true` — follows the same pattern as all other checks
- New outputs: `tests_result`, `tests_output`
- New row in PR comment table: `| Tests | ✅/⚠️/❌ |`
- New `<details>` block with verbose test output + coverage table
- Added `steps.tests.outcome == 'failure'` to the fail gate

### `requirements-dev.txt`
- Added: `pytest>=9.0`, `pytest-asyncio>=0.23`, `pytest-cov>=4.0`, `autohive-integrations-sdk`

## Safe to merge before integrations repo has tests

When no `test_*_unit.py` files exist for a changed integration, the script prints a warning and exits 0. Pytest is never invoked. The PR comment shows `⚠️ Passed with warnings` for the Tests row.

## Related

- Integration test infrastructure: autohive-ai/autohive-integrations branch `test/automated-testing-prototype`
- That branch adds `pyproject.toml`, `conftest.py`, `requirements-test.txt`, and unit tests for 5 integrations (hackernews, bitly, nzbn, notion, shopify-customer) — 177 tests, all mocked, all passing