### PR TITLE
feat: auto-move floating v2 tag on release

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,37 @@
+name: Move Floating Version Tag
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  move-tag:
+    runs-on: ubuntu-latest
+    name: Move v${{ github.event.release.major_version }} tag
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Move floating major tag
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+
+          # Extract major version number (handles both "2.0.3" and "v2.0.3")
+          MAJOR=$(echo "$VERSION" | sed 's/^v//' | cut -d. -f1)
+          FLOATING_TAG="v${MAJOR}"
+
+          echo "Release: $VERSION"
+          echo "Moving floating tag: $FLOATING_TAG → $VERSION"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Delete the old floating tag (if it exists) and re-create it at this commit
+          git tag -d "$FLOATING_TAG" 2>/dev/null || true
+          git push origin ":refs/tags/$FLOATING_TAG" 2>/dev/null || true
+          git tag "$FLOATING_TAG"
+          git push origin "$FLOATING_TAG"
+
+          echo "✅ $FLOATING_TAG now points to $VERSION"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -3,35 +3,63 @@ name: Move Floating Version Tag
 on:
   release:
     types: [published]
+  push:
+    branches: [master, main]
 
 jobs:
   move-tag:
     runs-on: ubuntu-latest
-    name: Move v${{ github.event.release.major_version }} tag
+    name: Move floating version tag
     permissions:
       contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Move floating major tag
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
-
-          # Extract major version number (handles both "2.0.3" and "v2.0.3")
-          MAJOR=$(echo "$VERSION" | sed 's/^v//' | cut -d. -f1)
-          FLOATING_TAG="v${MAJOR}"
-
-          echo "Release: $VERSION"
-          echo "Moving floating tag: $FLOATING_TAG → $VERSION"
-
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Delete the old floating tag (if it exists) and re-create it at this commit
-          git tag -d "$FLOATING_TAG" 2>/dev/null || true
-          git push origin ":refs/tags/$FLOATING_TAG" 2>/dev/null || true
-          git tag "$FLOATING_TAG"
-          git push origin "$FLOATING_TAG"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # Triggered by a release — move the tag for that release version
+            VERSION="${{ github.event.release.tag_name }}"
+            MAJOR=$(echo "$VERSION" | sed 's/^v//' | cut -d. -f1)
+            FLOATING_TAG="v${MAJOR}"
+            TARGET_SHA="${{ github.sha }}"
 
-          echo "✅ $FLOATING_TAG now points to $VERSION"
+            echo "Release: $VERSION"
+            echo "Moving $FLOATING_TAG → $VERSION ($TARGET_SHA)"
+
+            git tag -d "$FLOATING_TAG" 2>/dev/null || true
+            git push origin ":refs/tags/$FLOATING_TAG" 2>/dev/null || true
+            git tag "$FLOATING_TAG" "$TARGET_SHA"
+            git push origin "$FLOATING_TAG"
+
+            echo "✅ $FLOATING_TAG now points to $VERSION"
+
+          else
+            # Triggered by a push to master — bootstrap any missing floating tags
+            # Find the latest release tag and create vN if it doesn't exist yet
+            LATEST_TAG=$(git tag --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+
+            if [ -z "$LATEST_TAG" ]; then
+              echo "No release tags found, skipping"
+              exit 0
+            fi
+
+            MAJOR=$(echo "$LATEST_TAG" | cut -d. -f1)
+            FLOATING_TAG="v${MAJOR}"
+
+            if git ls-remote --tags origin "$FLOATING_TAG" | grep -q "$FLOATING_TAG"; then
+              echo "✅ $FLOATING_TAG already exists, nothing to do"
+            else
+              TAG_SHA=$(git rev-list -n 1 "$LATEST_TAG")
+              echo "Bootstrapping $FLOATING_TAG → $LATEST_TAG ($TAG_SHA)"
+              git tag "$FLOATING_TAG" "$TAG_SHA"
+              git push origin "$FLOATING_TAG"
+              echo "✅ $FLOATING_TAG created pointing at $LATEST_TAG"
+            fi
+          fi


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that automatically moves the floating `v2` tag to the latest release commit whenever a new release is published.

## Why

Consumer repos (`autohive-integrations` and `integrations`) currently pin an exact version like `@2.0.3`. Every release requires manually opening PRs in both repos to bump the version — and they can easily fall out of sync (they're already on different versions today).

With a floating `v2` tag, consumers pin `@v2` once and automatically get every `2.x.x` release. No more manual bumps until a major version change.

## How it works

1. You publish a release (e.g. `2.0.4`) as normal
2. This workflow fires automatically
3. It deletes the old `v2` tag and recreates it pointing at the new release commit
4. Both consumer repos on `@v2` immediately use the new version

## When v3 comes

Same thing — a `v3` tag gets created automatically on the first `3.x.x` release. Consumer repos update once from `@v2` → `@v3` when they're ready.

## Related

- Consumer repo PRs to switch to `@v2` are being raised separately