### PR TITLE
fix: clean up test runner output with summary table

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -22,6 +22,7 @@ Examples:
     python scripts/run_tests.py
 """
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -74,11 +75,11 @@ def get_integration_dirs(args: list[str]) -> list[Path]:
     )
 
 
-def install_integration_deps(integration_dir: Path) -> bool:
-    """Install an integration's requirements.txt. Returns True on success."""
+def install_integration_deps(integration_dir: Path) -> tuple[bool, str]:
+    """Install an integration's requirements.txt. Returns (success, error_output)."""
     req_file = integration_dir / "requirements.txt"
     if not req_file.is_file():
-        return True
+        return True, ""
 
     result = subprocess.run(
         [sys.executable, "-m", "pip", "install", "-r", str(req_file), "-q"],
@@ -86,16 +87,12 @@ def install_integration_deps(integration_dir: Path) -> bool:
         text=True,
     )
     if result.returncode != 0:
-        print(f"   ❌ Failed to install dependencies for {integration_dir.name}")
-        if result.stderr.strip():
-            for line in result.stderr.strip().splitlines():
-                print(f"      {line}")
-        return False
-    return True
+        return False, result.stderr.strip()
+    return True, ""
 
 
-def run_integration_tests(integration_dir: Path, test_files: list[Path]) -> int:
-    """Run pytest for a single integration. Returns the pytest exit code."""
+def run_integration_tests(integration_dir: Path, test_files: list[Path]) -> tuple[int, str]:
+    """Run pytest for a single integration. Returns (exit_code, output)."""
     cmd = [
         sys.executable,
         "-m",
@@ -103,16 +100,90 @@ def run_integration_tests(integration_dir: Path, test_files: list[Path]) -> int:
         "--import-mode=importlib",
         "-m",
         "unit",
-        "-v",
         "--tb=short",
         "--no-header",
+        "-q",
         "--cov",
         str(integration_dir),
         "--cov-report=term-missing:skip-covered",
         *[str(f) for f in test_files],
     ]
 
-    return subprocess.run(cmd).returncode
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result.returncode, result.stdout + result.stderr
+
+
+def parse_results(output: str) -> tuple[int, int, str]:
+    """Parse pytest output for passed count, failed count, and coverage."""
+    passed = failed = 0
+    coverage = "n/a"
+
+    # Match summary line e.g. "37 passed" or "2 failed, 35 passed"
+    summary = re.search(r"(\d+) passed", output)
+    if summary:
+        passed = int(summary.group(1))
+    fail_match = re.search(r"(\d+) failed", output)
+    if fail_match:
+        failed = int(fail_match.group(1))
+
+    # Match coverage total e.g. "TOTAL   166   13   92%"
+    cov_match = re.search(r"^TOTAL\s+\d+\s+\d+\s+(\d+%)", output, re.MULTILINE)
+    if cov_match:
+        coverage = cov_match.group(1)
+
+    return passed, failed, coverage
+
+
+def print_table(rows: list[tuple[str, str, str, str, str]], failed_outputs: dict[str, str]) -> None:
+    """Print a formatted results table."""
+    col_widths = [
+        max(len(r[0]) for r in rows) + 2,
+        8,   # Tests
+        10,  # Coverage
+        14,  # Status
+    ]
+
+    header = (
+        f"{'Integration':<{col_widths[0]}}"
+        f"{'Tests':>{col_widths[1]}}"
+        f"{'Coverage':>{col_widths[2]}}"
+        f"{'Status':>{col_widths[3]}}"
+    )
+    divider = "-" * len(header)
+
+    print()
+    print(header)
+    print(divider)
+    for name, tests, coverage, status, _ in rows:
+        print(
+            f"{name:<{col_widths[0]}}"
+            f"{tests:>{col_widths[1]}}"
+            f"{coverage:>{col_widths[2]}}"
+            f"{status:>{col_widths[3]}}"
+        )
+    print(divider)
+
+    # Total row
+    total_passed = sum(int(r[1].split("/")[0]) for r in rows if "/" in r[1])
+    total_total = sum(int(r[1].split("/")[1]) for r in rows if "/" in r[1])
+    all_passed = all(r[4] == "pass" for r in rows)
+    total_status = "✅ All passed" if all_passed else "❌ Some failed"
+    print(
+        f"{'Total':<{col_widths[0]}}"
+        f"{f'{total_passed}/{total_total}':>{col_widths[1]}}"
+        f"{'':>{col_widths[2]}}"
+        f"{total_status:>{col_widths[3]}}"
+    )
+    print()
+
+    # Print full output only for failures
+    for name, _, _, _, outcome in rows:
+        if outcome == "fail" and name in failed_outputs:
+            print(f"{'=' * 60}")
+            print(f"  {name} — failure detail")
+            print(f"{'=' * 60}")
+            print(failed_outputs[name])
+            print()
 
 
 def main() -> int:
@@ -140,37 +211,37 @@ def main() -> int:
         print("⚠️  No unit tests to run")
         return 0
 
-    print(f"🧪 Running unit tests for: {', '.join(d.name for d, _ in testable)}")
-    print()
-
     # Run each integration separately with its own dependencies
-    failed = []
-    passed = []
-    for d, test_files in testable:
-        print(f"{'=' * 60}")
-        print(f"  {d.name}")
-        print(f"{'=' * 60}")
+    rows = []
+    failed_outputs = {}
 
-        if not install_integration_deps(d):
-            failed.append(d.name)
+    for d, test_files in testable:
+        ok, err = install_integration_deps(d)
+        if not ok:
+            rows.append((d.name, "n/a", "n/a", "❌ Dep install failed", "fail"))
+            failed_outputs[d.name] = err
             continue
 
-        exit_code = run_integration_tests(d, test_files)
+        exit_code, output = run_integration_tests(d, test_files)
+        passed, failed, coverage = parse_results(output)
+        total = passed + failed
+        tests_str = f"{passed}/{total}"
+
         if exit_code == 0:
-            passed.append(d.name)
+            rows.append((d.name, tests_str, coverage, "✅ Passed", "pass"))
         else:
-            failed.append(d.name)
-        print()
+            rows.append((d.name, tests_str, coverage, "❌ Failed", "fail"))
+            failed_outputs[d.name] = output
 
-    # Summary
-    print("=" * 60)
-    if passed:
-        print(f"✅ Tests passed: {', '.join(passed)}")
-    if failed:
-        print(f"❌ Tests failed: {', '.join(failed)}")
-    print("=" * 60)
+    print_table(rows, failed_outputs)
 
-    return 1 if failed else 0
+    any_failed = any(r[4] == "fail" for r in rows)
+    if any_failed:
+        print(f"❌ Tests failed: {', '.join(r[0] for r in rows if r[4] == 'fail')}")
+    else:
+        print(f"✅ Tests passed: {', '.join(r[0] for r in rows if r[4] == 'pass')}")
+
+    return 1 if any_failed else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Test runner output was very noisy — all verbose per-test lines streamed directly to stdout, and due to CI buffering the section headers appeared empty at the bottom after all the pytest output had already been printed.

## Fix

Captures pytest output per integration instead of streaming it, then prints a clean summary table:

```
Integration       Tests    Coverage        Status
-------------------------------------------------
bitly             37/37         92%     ✅ Passed
hackernews        29/29         89%     ✅ Passed
notion            39/39         67%     ✅ Passed
nzbn              41/41         76%     ✅ Passed
shopify-customer  31/31         61%     ✅ Passed
-------------------------------------------------
Total            177/177              ✅ All passed
```

- Passing runs show only the table — no noise
- Failing runs show the table + full pytest output for the failed integration only
- Switched pytest from `-v` to `-q` since we no longer need per-test lines in the stream