### PR TITLE
feat(action): render PR comment to file and expose path output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,15 @@ outputs:
   tests_output:
     description: Full output of the test runner
     value: ${{ steps.tests.outputs.output }}
+  comment_path:
+    description: >
+      Path to a file containing the rendered Markdown PR comment body.
+      Empty when no integration directories changed. Useful for callers
+      that want to upload the comment as an artifact and post it from a
+      separate workflow (e.g. workflow_run) — typically required for
+      pull requests opened from forks, where the pull_request event
+      runs with a read-only GITHUB_TOKEN.
+    value: ${{ steps.render.outputs.path }}
 
 runs:
   using: composite
@@ -176,6 +185,38 @@ runs:
         fi
         exit $EXIT_CODE
 
+    - name: Render comment markdown
+      id: render
+      if: always() && steps.detect.outputs.dirs != ''
+      shell: bash
+      env:
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        SERVER_URL: ${{ github.server_url }}
+        REPOSITORY: ${{ github.repository }}
+        COMMIT_MSG: ${{ steps.detect.outputs.commit_msg }}
+        UPDATED_AT: ${{ github.event.pull_request.updated_at }}
+        DIRS: ${{ steps.detect.outputs.dirs }}
+        STRUCTURE_OUTCOME: ${{ steps.structure.outcome }}
+        STRUCTURE_WARN: ${{ steps.structure.outputs.has_warnings }}
+        STRUCTURE_OUTPUT: ${{ steps.structure.outputs.output }}
+        CODE_OUTCOME: ${{ steps.code.outcome }}
+        CODE_WARN: ${{ steps.code.outputs.has_warnings }}
+        CODE_OUTPUT: ${{ steps.code.outputs.output }}
+        TESTS_OUTCOME: ${{ steps.tests.outcome }}
+        TESTS_WARN: ${{ steps.tests.outputs.has_warnings }}
+        TESTS_OUTPUT: ${{ steps.tests.outputs.output }}
+        README_OUTCOME: ${{ steps.readme.outcome }}
+        README_WARN: ${{ steps.readme.outputs.has_warnings }}
+        README_OUTPUT: ${{ steps.readme.outputs.output }}
+        VERSION_OUTCOME: ${{ steps.version.outcome }}
+        VERSION_WARN: ${{ steps.version.outputs.has_warnings }}
+        VERSION_OUTPUT: ${{ steps.version.outputs.output }}
+      run: |
+        set -euo pipefail
+        OUT="${{ runner.temp }}/validation-comment.md"
+        python "${{ github.action_path }}/scripts/render_comment.py" > "$OUT"
+        echo "path=$OUT" >> "$GITHUB_OUTPUT"
+
     - name: Delete stale PR comment
       if: always() && steps.detect.outputs.dirs == '' && inputs.post_comment == 'true'
       uses: marocchino/sticky-pull-request-comment@v2
@@ -188,61 +229,7 @@ runs:
       uses: marocchino/sticky-pull-request-comment@v2
       with:
         header: validation-results
-        message: |
-          ## 🔍 Integration Validation Results
-
-          **Commit:** [`${{ github.event.pull_request.head.sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }}) · ${{ steps.detect.outputs.commit_msg }}
-          **Updated:** ${{ github.event.pull_request.updated_at }}
-
-          **Changed directories:** `${{ steps.detect.outputs.dirs }}`
-
-          | Check | Result |
-          |-------|--------|
-          | Structure | ${{ steps.structure.outcome == 'failure' && '❌ Failed' || (steps.structure.outputs.has_warnings == 'true' && '⚠️ Passed with warnings' || '✅ Passed') }} |
-          | Code | ${{ steps.code.outcome == 'failure' && '❌ Failed' || (steps.code.outputs.has_warnings == 'true' && '⚠️ Passed with warnings' || '✅ Passed') }} |
-          | Tests | ${{ steps.tests.outcome == 'failure' && '❌ Failed' || (steps.tests.outputs.has_warnings == 'true' && '⚠️ Passed with warnings' || '✅ Passed') }} |
-          | README | ${{ steps.readme.outcome == 'failure' && '❌ Failed' || (steps.readme.outputs.has_warnings == 'true' && '⚠️ Passed with warnings' || '✅ Passed') }} |
-          | Version | ${{ steps.version.outcome == 'failure' && '❌ Failed' || (steps.version.outputs.has_warnings == 'true' && '⚠️ Passed with warnings' || '✅ Passed') }} |
-
-          <details><summary>${{ steps.structure.outcome == 'failure' && '❌' || (steps.structure.outputs.has_warnings == 'true' && '⚠️' || '✅') }} Structure Check output</summary>
-
-          ```
-          ${{ steps.structure.outputs.output }}
-          ```
-
-          </details>
-
-          <details><summary>${{ steps.code.outcome == 'failure' && '❌' || (steps.code.outputs.has_warnings == 'true' && '⚠️' || '✅') }} Code Check output</summary>
-
-          ```
-          ${{ steps.code.outputs.output }}
-          ```
-
-          </details>
-
-          <details><summary>${{ steps.tests.outcome == 'failure' && '❌' || (steps.tests.outputs.has_warnings == 'true' && '⚠️' || '✅') }} Tests output</summary>
-
-          ```
-          ${{ steps.tests.outputs.output }}
-          ```
-
-          </details>
-
-          <details><summary>${{ steps.readme.outcome == 'failure' && '❌' || (steps.readme.outputs.has_warnings == 'true' && '⚠️' || '✅') }} README Check output</summary>
-
-          ```
-          ${{ steps.readme.outputs.output }}
-          ```
-
-          </details>
-
-          <details><summary>${{ steps.version.outcome == 'failure' && '❌' || (steps.version.outputs.has_warnings == 'true' && '⚠️' || '✅') }} Version Check output</summary>
-
-          ```
-          ${{ steps.version.outputs.output }}
-          ```
-
-          </details>
+        path: ${{ steps.render.outputs.path }}
 
     - name: Fail if any check failed
       if: always() && (steps.structure.outcome == 'failure' || steps.code.outcome == 'failure' || steps.tests.outcome == 'failure' || steps.readme.outcome == 'failure' || steps.version.outcome == 'failure')

--- a/scripts/render_comment.py
+++ b/scripts/render_comment.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Render the validation-results PR comment as Markdown to stdout.
+
+All inputs are read from environment variables so that multi-line tool
+output (which can contain backticks, ``EOF`` markers, etc.) is handled
+correctly without any YAML or heredoc escaping.
+
+Expected env vars per check (prefix is one of STRUCTURE / CODE / TESTS /
+README / VERSION):
+
+    {PREFIX}_OUTCOME   one of "success", "failure", "skipped", ""
+    {PREFIX}_WARN      "true" if the check emitted warnings
+    {PREFIX}_OUTPUT    full captured stdout/stderr of the check
+
+Plus context vars: HEAD_SHA, SERVER_URL, REPOSITORY, COMMIT_MSG,
+UPDATED_AT, DIRS.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+CHECKS: list[tuple[str, str]] = [
+    ("Structure", "STRUCTURE"),
+    ("Code", "CODE"),
+    ("Tests", "TESTS"),
+    ("README", "README"),
+    ("Version", "VERSION"),
+]
+
+
+def _status(outcome: str, has_warnings: str) -> tuple[str, str]:
+    """Return (icon, table_text) for a check result."""
+    if outcome == "failure":
+        return "❌", "❌ Failed"
+    if has_warnings == "true":
+        return "⚠️", "⚠️ Passed with warnings"
+    return "✅", "✅ Passed"
+
+
+def _section(label: str, prefix: str) -> str:
+    outcome = os.environ.get(f"{prefix}_OUTCOME", "")
+    warn = os.environ.get(f"{prefix}_WARN", "")
+    output = os.environ.get(f"{prefix}_OUTPUT", "") or "(no output)"
+    icon, _ = _status(outcome, warn)
+    return (
+        f"<details><summary>{icon} {label} Check output</summary>\n\n"
+        f"```\n{output}\n```\n\n"
+        f"</details>\n"
+    )
+
+
+def main() -> int:
+    head_sha = os.environ.get("HEAD_SHA", "")
+    server_url = os.environ.get("SERVER_URL", "")
+    repository = os.environ.get("REPOSITORY", "")
+    commit_msg = os.environ.get("COMMIT_MSG", "")
+    updated_at = os.environ.get("UPDATED_AT", "")
+    dirs = os.environ.get("DIRS", "")
+
+    rows = []
+    for label, prefix in CHECKS:
+        outcome = os.environ.get(f"{prefix}_OUTCOME", "")
+        warn = os.environ.get(f"{prefix}_WARN", "")
+        _, text = _status(outcome, warn)
+        rows.append(f"| {label} | {text} |")
+
+    sections = [_section(label, prefix) for label, prefix in CHECKS]
+
+    md = (
+        "## 🔍 Integration Validation Results\n\n"
+        f"**Commit:** [`{head_sha}`]({server_url}/{repository}/commit/{head_sha})"
+        f" · {commit_msg}\n"
+        f"**Updated:** {updated_at}\n\n"
+        f"**Changed directories:** `{dirs}`\n\n"
+        "| Check | Result |\n"
+        "|-------|--------|\n"
+        + "\n".join(rows)
+        + "\n\n"
+        + "\n".join(sections)
+    )
+    sys.stdout.write(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #37.

## What

Renders the validation-results PR comment Markdown body to a file (`${{ runner.temp }}/validation-comment.md`) and exposes the path via a new `comment_path` action output. The existing `Post PR comment` step now reads from that file via marocchino's `path:` input instead of an inline `message:` block.

This is the **tooling-repo half** of the fix for fork PRs not getting validation-results comments. The follow-up consumer-repo PR in `autohive-ai/autohive-integrations` will set `post_comment: 'false'`, upload the rendered file as an artifact, and add a `workflow_run`-triggered companion workflow that posts the comment from the base-repo context (where the `GITHUB_TOKEN` actually has `pull-requests: write` even for fork PRs).

## Why

`pull_request` workflows triggered from forks always run with a **read-only** `GITHUB_TOKEN` regardless of the workflow's `permissions:` block ([docs](https://docs.github.com/actions/security-guides/automatic-token-authentication)). So the existing inline comment step always 403s on fork PRs and the job conclusion goes ❌ even when all five validation checks passed. Concrete example: [autohive-ai/autohive-integrations#293](https://github.com/Autohive-AI/autohive-integrations/pull/293) (HubSpot tasks, opened from `lohitya/autohive-integrations`).

The standard fix is the two-workflow pattern, which needs the comment body to be available as a file (otherwise the consumer workflow has to duplicate the entire ~40-line template). Hence this change.

## Files

- `scripts/render_comment.py` (new) — reads check outcomes / outputs from env vars and prints the Markdown body to stdout. Using env vars rather than `${{ steps.X.outputs }}` YAML interpolation avoids escaping issues with multi-line tool output, embedded backticks, and `EOF` markers.
- `action.yml`:
  - Adds a `Render comment markdown` step (`id: render`) that runs the new script and writes to `${{ runner.temp }}/validation-comment.md`.
  - Adds a `comment_path` output exposing that path.
  - Switches the existing `Post PR comment` step from inline `message:` to `path:` (reads from the same file).

## Backward compatibility

Strictly additive:

- No existing inputs / outputs are removed or renamed.
- Default behaviour for `post_comment: 'true'` (same-repo PRs) is unchanged — the same `marocchino/sticky-pull-request-comment@v2` step posts the same comment, just reading the body from a file instead of an inline string.
- Existing consumers pinned at `@v2` continue to work without changes when the `v2` tag is moved to the merge commit.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('action.yml'))"` — YAML parses cleanly.
- `render_comment.py` smoke-tested locally with multi-line / embedded-`EOF` / backtick payloads — produces the expected Markdown.

## Out of scope (follow-up PR in `autohive-integrations`)

- Setting `post_comment: 'false'` and uploading the rendered file as an artifact in `validate-integration.yml`.
- Adding `validate-integration-comment.yml` (the `workflow_run` companion that downloads the artifact and posts the comment from base-repo context).
- Retagging `v2` after this PR merges.