### PR TITLE
fix: fail input drift for new integrations

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -119,6 +119,26 @@ jobs:
           fi
           echo "✅ Config-code mismatch correctly detected"
 
+      - name: Test check_config_sync.py — input drift warns for existing integrations
+        run: |
+          OUTPUT=$(python scripts/check_config_sync.py --base-ref HEAD tests/examples/input-drift 2>&1)
+          if ! echo "$OUTPUT" | grep -q "historic warning"; then
+            echo "❌ Expected input drift to be treated as historic warning for existing integration"
+            echo "$OUTPUT"
+            exit 1
+          fi
+          echo "✅ Existing integration input drift warned without failing"
+
+      - name: Test check_config_sync.py — input drift fails for new integrations
+        run: |
+          cp -R tests/examples/input-drift tmp-input-drift
+          trap 'rm -rf tmp-input-drift' EXIT
+          if python scripts/check_config_sync.py --base-ref HEAD tmp-input-drift 2>&1; then
+            echo "❌ Expected input drift to fail for new integration"
+            exit 1
+          fi
+          echo "✅ New integration input drift correctly failed"
+
       - name: Test validate_integration.py — deprecated SDK pin warns
         run: |
           OUTPUT=$(python scripts/validate_integration.py tests/examples/sdk-deprecated-pin 2>&1)

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -129,6 +129,62 @@ jobs:
           fi
           echo "✅ Existing integration input drift warned without failing"
 
+      - name: Test check_config_sync.py — base ref works from outside repository
+        run: |
+          OUTPUT=$(cd /tmp && python "$GITHUB_WORKSPACE/scripts/check_config_sync.py" --base-ref HEAD "$GITHUB_WORKSPACE/tests/examples/input-drift" 2>&1)
+          if ! echo "$OUTPUT" | grep -q "historic warning"; then
+            echo "❌ Expected absolute-path input drift check to resolve base ref from integration repo"
+            echo "$OUTPUT"
+            exit 1
+          fi
+          echo "✅ Base ref resolved correctly when run outside the repository"
+
+      - name: Test check_config_sync.py — renamed integrations remain existing integrations
+        run: |
+          TMP_REPO=$(mktemp -d)
+          trap 'rm -rf "$TMP_REPO"' EXIT
+          cd "$TMP_REPO"
+          git init -q
+          git config user.email test@example.com
+          git config user.name Test
+          mkdir -p old-integration
+          cat > old-integration/config.json <<'JSON'
+          {
+            "entry_point": "main.py",
+            "actions": {
+              "get_data": {
+                "input_schema": {
+                  "type": "object",
+                  "properties": {
+                    "unused_param": {"type": "string"}
+                  }
+                }
+              }
+            }
+          }
+          JSON
+          cat > old-integration/main.py <<'PY'
+          app = None
+
+          @app.action("get_data")
+          class GetData:
+              def execute(self, inputs):
+                  return inputs.get("undocumented_param")
+          PY
+          git add old-integration
+          git commit -q -m base
+          BASE_REF=$(git rev-parse HEAD)
+          git mv old-integration renamed-integration
+          git commit -q -m rename
+
+          OUTPUT=$(python "$GITHUB_WORKSPACE/scripts/check_config_sync.py" --base-ref "$BASE_REF" renamed-integration 2>&1)
+          if ! echo "$OUTPUT" | grep -q "historic warning"; then
+            echo "❌ Expected renamed integration input drift to remain warning-only"
+            echo "$OUTPUT"
+            exit 1
+          fi
+          echo "✅ Renamed integration input drift warned without failing"
+
       - name: Test check_config_sync.py — input drift fails for new integrations
         run: |
           cp -R tests/examples/input-drift tmp-input-drift
@@ -162,11 +218,26 @@ jobs:
         run: |
           cp -R tests/examples/input-drift tmp-input-drift
           trap 'rm -rf tmp-input-drift' EXIT
-          if python scripts/check_code.py --base-ref HEAD tmp-input-drift 2>&1; then
+          OUTPUT=$(python scripts/check_code.py --base-ref HEAD tmp-input-drift 2>&1) && {
             echo "❌ Expected input drift to fail through check_code.py for new integration"
+            echo "$OUTPUT"
+            exit 1
+          }
+          if ! echo "$OUTPUT" | grep -q "New integrations must keep config.json input_schema in sync with code"; then
+            echo "❌ Expected new-integration config-sync failure to flow through check_code.py"
+            echo "$OUTPUT"
             exit 1
           fi
           echo "✅ New integration input drift correctly failed through check_code.py"
+
+      - name: Test check_code.py — invalid base ref returns processing error
+        run: |
+          python scripts/check_code.py --base-ref definitely-not-a-ref tests/examples/good-integration 2>&1 || EXIT_CODE=$?
+          if [ "${EXIT_CODE:-0}" -ne 2 ]; then
+            echo "❌ Expected exit code 2 for invalid base ref through check_code.py, got ${EXIT_CODE:-0}"
+            exit 1
+          fi
+          echo "✅ Invalid base ref correctly returns exit code 2 through check_code.py"
 
       - name: Test validate_integration.py — deprecated SDK pin warns
         run: |

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -139,6 +139,35 @@ jobs:
           fi
           echo "✅ New integration input drift correctly failed"
 
+      - name: Test check_config_sync.py — invalid base ref returns processing error
+        run: |
+          python scripts/check_config_sync.py --base-ref definitely-not-a-ref tests/examples/good-integration 2>&1 || EXIT_CODE=$?
+          if [ "${EXIT_CODE:-0}" -ne 2 ]; then
+            echo "❌ Expected exit code 2 for invalid base ref, got ${EXIT_CODE:-0}"
+            exit 1
+          fi
+          echo "✅ Invalid base ref correctly returns exit code 2"
+
+      - name: Test check_code.py — input drift warns for existing integrations
+        run: |
+          OUTPUT=$(python scripts/check_code.py --base-ref HEAD tests/examples/input-drift 2>&1)
+          if ! echo "$OUTPUT" | grep -q "historic warning"; then
+            echo "❌ Expected input drift warning to flow through check_code.py"
+            echo "$OUTPUT"
+            exit 1
+          fi
+          echo "✅ Existing integration input drift warned through check_code.py"
+
+      - name: Test check_code.py — input drift fails for new integrations
+        run: |
+          cp -R tests/examples/input-drift tmp-input-drift
+          trap 'rm -rf tmp-input-drift' EXIT
+          if python scripts/check_code.py --base-ref HEAD tmp-input-drift 2>&1; then
+            echo "❌ Expected input drift to fail through check_code.py for new integration"
+            exit 1
+          fi
+          echo "✅ New integration input drift correctly failed through check_code.py"
+
       - name: Test validate_integration.py — deprecated SDK pin warns
         run: |
           OUTPUT=$(python scripts/validate_integration.py tests/examples/sdk-deprecated-pin 2>&1)

--- a/LOCAL_DEVELOPMENT.md
+++ b/LOCAL_DEVELOPMENT.md
@@ -206,7 +206,7 @@ Detailed documentation for each validation script — usage, arguments, exit cod
 | Document | Script | When to read it |
 |----------|--------|-----------------|
 | [validate_integration.md](scripts/docs/validate_integration.md) | `validate_integration.py` | Understanding what structure/config checks are performed and why |
-| [check_code.md](scripts/docs/check_code.md) | `check_code.py` | Understanding the 9 code quality checks and their failure output |
+| [check_code.md](scripts/docs/check_code.md) | `check_code.py` | Understanding the 10 code quality checks and their failure output |
 | [check_imports.md](scripts/docs/check_imports.md) | `check_imports.py` | Understanding how imports are resolved (AST parsing, relative imports, `--verify-names`) |
 | [check_config_sync.md](scripts/docs/check_config_sync.md) | `check_config_sync.py` | Understanding how config.json is cross-validated against code (AST-based action and input detection) |
 | [check_readme.md](scripts/docs/check_readme.md) | `check_readme.py` | Understanding the README update requirement for new integrations |

--- a/LOCAL_DEVELOPMENT.md
+++ b/LOCAL_DEVELOPMENT.md
@@ -54,7 +54,7 @@ This is the comprehensive check — it runs 10 steps in sequence:
 9. Cross-validates `config.json` against your code (`check_config_sync`)
 10. Checks SDK 2.x `context.fetch()` response handling (`check_fetch_pattern`)
 
-When run with `--base-ref`, config/code input drift is still only a warning for integrations that already existed at that ref, but it fails for brand-new integrations:
+When run with `--base-ref`, config/code input drift is still only a warning for integrations that already existed at that ref, but it fails for brand-new integrations. The base ref must be fetched locally:
 
 ```bash
 python scripts/check_code.py --base-ref origin/main my-integration
@@ -97,7 +97,7 @@ python scripts/check_config_sync.py my-integration
 python scripts/check_config_sync.py --base-ref origin/main my-integration
 ```
 
-Useful when you've added or renamed actions and want to verify `config.json` matches your `@action` decorators and `inputs` access patterns. Action mismatches always fail. Input drift warns for existing integrations, and fails for new integrations when `--base-ref` is provided.
+Useful when you've added or renamed actions and want to verify `config.json` matches your `@action` decorators and `inputs` access patterns. Action mismatches always fail. Input drift warns for existing integrations, and fails for new integrations when `--base-ref` is provided. Renamed integration directories are treated as existing when git rename detection can match their `config.json` to the previous path.
 
 ### Check multiple integrations
 

--- a/LOCAL_DEVELOPMENT.md
+++ b/LOCAL_DEVELOPMENT.md
@@ -41,7 +41,7 @@ Run this **first** — it catches structural problems before you waste time on c
 python scripts/check_code.py my-integration
 ```
 
-This is the comprehensive check — it runs 9 steps in sequence:
+This is the comprehensive check — it runs 10 steps in sequence:
 
 1. Installs your `requirements.txt` dependencies
 2. Checks Python syntax (`py_compile`)
@@ -52,6 +52,13 @@ This is the comprehensive check — it runs 9 steps in sequence:
 7. Scans for security issues with `bandit`
 8. Audits dependencies for known CVEs with `pip-audit`
 9. Cross-validates `config.json` against your code (`check_config_sync`)
+10. Checks SDK 2.x `context.fetch()` response handling (`check_fetch_pattern`)
+
+When run with `--base-ref`, config/code input drift is still only a warning for integrations that already existed at that ref, but it fails for brand-new integrations:
+
+```bash
+python scripts/check_code.py --base-ref origin/main my-integration
+```
 
 ### 3. Fix common issues
 
@@ -85,9 +92,12 @@ python scripts/check_imports.py --verify-names my-integration/my_integration.py
 
 ```bash
 python scripts/check_config_sync.py my-integration
+
+# Fail input drift when this is a brand-new integration compared with the base ref
+python scripts/check_config_sync.py --base-ref origin/main my-integration
 ```
 
-Useful when you've added or renamed actions and want to verify `config.json` matches your `@action` decorators and `inputs` access patterns.
+Useful when you've added or renamed actions and want to verify `config.json` matches your `@action` decorators and `inputs` access patterns. Action mismatches always fail. Input drift warns for existing integrations, and fails for new integrations when `--base-ref` is provided.
 
 ### Check multiple integrations
 
@@ -115,7 +125,7 @@ python scripts/get_changed_dirs.py origin/main
 # Run the full CI pipeline locally against those dirs
 DIRS=$(python scripts/get_changed_dirs.py origin/main)
 python scripts/validate_integration.py $DIRS
-python scripts/check_code.py $DIRS
+python scripts/check_code.py --base-ref origin/main $DIRS
 python scripts/check_readme.py origin/main $DIRS
 python scripts/check_version_bump.py origin/main $DIRS
 ```
@@ -167,7 +177,7 @@ The `validate-integration.yml` workflow uses the composite action defined in `ac
 |------|--------|-------------|
 | 1 | `get_changed_dirs.py` | Detects which integration folders changed |
 | 2 | `validate_integration.py` | Structure and config validation |
-| 3 | `check_code.py` | Syntax, imports, JSON, lint, format, security, deps, config sync |
+| 3 | `check_code.py` | Syntax, imports, JSON, lint, format, security, deps, config sync, fetch pattern checks |
 | 4 | `run_tests.py` | Installs each integration's deps, runs `test_*_unit.py` files (unit tests only) |
 | 5 | `check_readme.py` | Checks that the main README.md was updated for new integrations |
 | 6 | `check_version_bump.py` | Checks that config.json version was incremented, recommends bump level |

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ flowchart TB
 |------|--------|--------|
 | Detect changes | `get_changed_dirs.py` | `git diff` → extract top-level dirs, filter out `.github`, `scripts`, `tests` |
 | Structure check | `validate_integration.py` | Folder name, required files, config.json schema, `__init__.py`, requirements.txt, tests/, icon size, unused scopes |
-| Code check | `check_code.py` | pip install, py_compile, check_imports, JSON validity, ruff check, ruff format, bandit, pip-audit, check_config_sync |
+| Code check | `check_code.py` | pip install, py_compile, check_imports, JSON validity, ruff check, ruff format, bandit, pip-audit, check_config_sync, check_fetch_pattern |
 | Tests | `run_tests.py` | Installs each integration's dependencies, then discovers and runs `test_*_unit.py` files with pytest per-integration. Warns (does not fail) if no unit tests exist |
 | README check | `check_readme.py` | New integration files added → was README.md also updated? |
 | Version check | `check_version_bump.py` | Version in config.json incremented? Recommends major/minor/patch based on config and code changes |
@@ -175,6 +175,9 @@ python scripts/validate_integration.py my-integration
 
 # Run code quality checks (syntax, imports, JSON, lint, format, security, deps, config sync)
 python scripts/check_code.py my-integration
+
+# In PR/CI mode, pass a base ref so config/input drift fails for brand-new integrations
+python scripts/check_code.py --base-ref origin/main my-integration
 
 # Check all imports in a file
 python scripts/check_imports.py my-integration/main.py

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ uv pip install -r requirements-dev.txt
 # Validate structure and config
 python scripts/validate_integration.py my-integration
 
-# Run code quality checks (syntax, imports, JSON, lint, format, security, deps, config sync)
+# Run code quality checks (syntax, imports, JSON, lint, format, security, deps, config sync, fetch pattern)
 python scripts/check_code.py my-integration
 
 # In PR/CI mode, pass a base ref so config/input drift fails for brand-new integrations

--- a/action.yml
+++ b/action.yml
@@ -120,7 +120,11 @@ runs:
       shell: bash
       run: |
         set +e
-        OUTPUT=$(python ${{ github.action_path }}/scripts/check_code.py ${{ steps.detect.outputs.dirs }} 2>&1)
+        BASE_REF_ARGS=()
+        if [ -n "${{ inputs.base_ref }}" ]; then
+          BASE_REF_ARGS=(--base-ref "${{ inputs.base_ref }}")
+        fi
+        OUTPUT=$(python ${{ github.action_path }}/scripts/check_code.py "${BASE_REF_ARGS[@]}" ${{ steps.detect.outputs.dirs }} 2>&1)
         EXIT_CODE=$?
         echo "$OUTPUT"
         echo 'output<<EOF' >> $GITHUB_OUTPUT

--- a/scripts/check_code.py
+++ b/scripts/check_code.py
@@ -18,9 +18,10 @@ Checks performed per directory:
     7. Security scan (bandit)
     8. Dependency vulnerability scan (pip-audit)
     9. Config-code sync check (check_config_sync)
+    10. Fetch pattern check (check_fetch_pattern)
 
 Usage:
-    python scripts/check_code.py <dir> [dir ...]
+    python scripts/check_code.py [--base-ref <ref>] <dir> [dir ...]
 
 Exit codes:
     0 - All checks passed
@@ -29,6 +30,7 @@ Exit codes:
 
 Examples:
     $ python scripts/check_code.py my-integration
+    $ python scripts/check_code.py --base-ref origin/main my-integration
     $ python scripts/check_code.py integration-a integration-b
 """
 
@@ -51,11 +53,12 @@ BANDIT_EXCLUDE_DIRS = [".venv", "venv", "__pycache__", "site-packages", "depende
 RUFF_CONFIG = str(Path(__file__).resolve().parent.parent / "ruff.toml")
 
 
-def check_code(dirs: list[str]) -> int:
+def check_code(dirs: list[str], *, base_ref: str | None = None) -> int:
     """Run code quality checks on the given integration directories.
 
     Args:
         dirs: List of directory paths to check.
+        base_ref: Optional git ref used to make config/input drift fatal for new integrations.
 
     Returns:
         0 if all checks passed, 1 if any check failed.
@@ -247,7 +250,7 @@ def check_code(dirs: list[str]) -> int:
         print("🔗 Checking config-code sync...")
         buf = io.StringIO()
         with redirect_stdout(buf):
-            sync_result = check_config_sync(str(dir_path))
+            sync_result = check_config_sync(str(dir_path), base_ref=base_ref)
         if sync_result != 0:
             for line in buf.getvalue().splitlines():
                 if line.strip():
@@ -309,6 +312,10 @@ Examples:
 """,
     )
     parser.add_argument(
+        "--base-ref",
+        help="Git ref to compare against; config/input drift fails only for integrations new at this ref",
+    )
+    parser.add_argument(
         "dirs",
         nargs="+",
         metavar="dir",
@@ -316,7 +323,7 @@ Examples:
     )
 
     args = parser.parse_args()
-    return check_code(args.dirs)
+    return check_code(args.dirs, base_ref=args.base_ref)
 
 
 if __name__ == "__main__":

--- a/scripts/check_code.py
+++ b/scripts/check_code.py
@@ -26,7 +26,7 @@ Usage:
 Exit codes:
     0 - All checks passed
     1 - One or more checks failed
-    2 - No directories provided (handled by argparse)
+    2 - Usage or processing error (including unresolvable --base-ref from config-code sync)
 
 Examples:
     $ python scripts/check_code.py my-integration
@@ -40,7 +40,7 @@ import json
 import py_compile
 import subprocess
 import sys
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 # Allow importing check_imports from the same directory regardless of cwd
@@ -61,9 +61,9 @@ def check_code(dirs: list[str], *, base_ref: str | None = None) -> int:
         base_ref: Optional git ref used to make config/input drift fatal for new integrations.
 
     Returns:
-        0 if all checks passed, 1 if any check failed.
+        0 if all checks passed, 1 if any check failed, 2 on processing errors.
     """
-    failed = False
+    exit_code = 0
 
     # Ensure tools are available
     subprocess.run(
@@ -102,7 +102,7 @@ def check_code(dirs: list[str], *, base_ref: str | None = None) -> int:
             except py_compile.PyCompileError:
                 print(f"   ❌ {pyfile}")
                 syntax_ok = False
-                failed = True
+                exit_code = max(exit_code, 1)
 
         if syntax_ok:
             print("   ✅ Syntax OK")
@@ -139,7 +139,7 @@ def check_code(dirs: list[str], *, base_ref: str | None = None) -> int:
                     print()
                     print("   Fix: Install missing packages in requirements.txt")
                     print("   Or check if package name is spelled correctly")
-                    failed = True
+                    exit_code = max(exit_code, 1)
                 else:
                     print("   ✅ Imports OK")
             else:
@@ -158,7 +158,7 @@ def check_code(dirs: list[str], *, base_ref: str | None = None) -> int:
             except (json.JSONDecodeError, OSError):
                 print(f"   ❌ {jsonfile}")
                 json_ok = False
-                failed = True
+                exit_code = max(exit_code, 1)
 
         if json_ok:
             print("   ✅ JSON files OK")
@@ -181,7 +181,7 @@ def check_code(dirs: list[str], *, base_ref: str | None = None) -> int:
             print("   ❌ Lint errors found")
             print()
             print("   Fix: Run 'ruff check --fix' to auto-fix some issues")
-            failed = True
+            exit_code = max(exit_code, 1)
         else:
             print("   ✅ Lint OK")
         print()
@@ -199,7 +199,7 @@ def check_code(dirs: list[str], *, base_ref: str | None = None) -> int:
             print("   ❌ Formatting issues found")
             print()
             print("   Fix: Run 'ruff format' to auto-format")
-            failed = True
+            exit_code = max(exit_code, 1)
         else:
             print("   ✅ Formatting OK")
         print()
@@ -220,7 +220,7 @@ def check_code(dirs: list[str], *, base_ref: str | None = None) -> int:
             print()
             print("   Fix: Review flagged code for security risks")
             print(f"   Run locally: bandit -r <dir> -x {','.join(BANDIT_EXCLUDE_DIRS)} -s B101")
-            failed = True
+            exit_code = max(exit_code, 1)
         else:
             print("   ✅ Security OK")
         print()
@@ -241,26 +241,33 @@ def check_code(dirs: list[str], *, base_ref: str | None = None) -> int:
                 print("   ❌ Vulnerable dependencies found")
                 print()
                 print("   Fix: Update affected packages in requirements.txt")
-                failed = True
+                exit_code = max(exit_code, 1)
             else:
                 print("   ✅ Dependencies OK")
             print()
 
         # Config-code sync check
         print("🔗 Checking config-code sync...")
-        buf = io.StringIO()
-        with redirect_stdout(buf):
+        stdout_buf = io.StringIO()
+        stderr_buf = io.StringIO()
+        with redirect_stdout(stdout_buf), redirect_stderr(stderr_buf):
             sync_result = check_config_sync(str(dir_path), base_ref=base_ref)
         if sync_result != 0:
-            for line in buf.getvalue().splitlines():
+            for line in (stdout_buf.getvalue() + stderr_buf.getvalue()).splitlines():
                 if line.strip():
                     print(f"   {line}")
-            print("   ❌ Config and code are out of sync")
+            if sync_result == 2:
+                print("   ❌ Config-code sync could not complete")
+            else:
+                print("   ❌ Config and code are out of sync")
             print()
-            print("   Fix: Ensure config.json actions and input_schema match the code")
-            failed = True
+            if sync_result == 2:
+                print("   Fix: Resolve the processing error above, then rerun the check")
+            else:
+                print("   Fix: Ensure config.json actions and input_schema match the code")
+            exit_code = max(exit_code, sync_result)
         else:
-            output = buf.getvalue()
+            output = stdout_buf.getvalue()
             # Show warnings even on success
             warning_lines = [line for line in output.splitlines() if line.startswith("⚠️")]
             if warning_lines:
@@ -281,16 +288,16 @@ def check_code(dirs: list[str], *, base_ref: str | None = None) -> int:
             print("   ❌ Fetch pattern issues found")
             print()
             print("   Fix: SDK 2.x returns FetchResponse — use response.data to access the body")
-            failed = True
+            exit_code = max(exit_code, 1)
         else:
             print("   ✅ Fetch patterns OK")
         print()
 
     print("========================================")
-    if failed:
+    if exit_code != 0:
         print("❌ CODE CHECK FAILED")
         print("========================================")
-        return 1
+        return exit_code
     print("✅ CODE CHECK PASSED")
     print("========================================")
     return 0
@@ -305,9 +312,11 @@ def main() -> int:
 Exit codes:
   0  All checks passed
   1  One or more checks failed
+  2  Usage or processing error
 
 Examples:
   %(prog)s my-integration
+  %(prog)s --base-ref origin/main my-integration
   %(prog)s integration-a integration-b
 """,
     )

--- a/scripts/check_config_sync.py
+++ b/scripts/check_config_sync.py
@@ -21,21 +21,23 @@ How it determines required vs optional from code:
     - inputs.get("key")   -> optional (returns None/default if missing)
 
 Usage:
-    python scripts/check_config_sync.py <dir> [dir ...]
+    python scripts/check_config_sync.py [--base-ref <ref>] <dir> [dir ...]
 
 Exit codes:
     0 - Config and code are in sync (possibly with warnings)
-    1 - Mismatches found
+    1 - Mismatches found, or input drift found in a new integration when --base-ref is provided
     2 - An error occurred (file not found, syntax error, etc.)
 
 Examples:
     python scripts/check_config_sync.py my-integration
+    python scripts/check_config_sync.py --base-ref origin/main my-integration
     python scripts/check_config_sync.py my-integration another-api
 """
 
 import argparse
 import ast
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -149,11 +151,43 @@ def extract_actions_from_config(config: dict) -> dict[str, dict]:
     return actions
 
 
-def check_config_sync(dir_path: str) -> int:
+def _git_path(path: Path) -> str:
+    """Return a repository-relative path for git object lookups when possible."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return path.as_posix()
+
+    repo_root = Path(result.stdout.strip()).resolve()
+    try:
+        return path.resolve().relative_to(repo_root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _is_new_integration(dir_path: Path, base_ref: str | None) -> bool:
+    """Return True when config.json did not exist at base_ref."""
+    if not base_ref:
+        return False
+
+    config_ref = f"{base_ref}:{_git_path(dir_path / 'config.json')}"
+    result = subprocess.run(
+        ["git", "cat-file", "-e", config_ref],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode != 0
+
+
+def check_config_sync(dir_path: str, *, base_ref: str | None = None) -> int:
     """Check that config.json and code are in sync for an integration directory.
 
     Args:
         dir_path: Path to the integration directory.
+        base_ref: Optional git ref used to decide whether this is a new integration.
 
     Returns:
         0 if in sync, 1 if mismatches found, 2 on errors.
@@ -192,6 +226,7 @@ def check_config_sync(dir_path: str) -> int:
 
     errors: list[str] = []
     warnings: list[str] = []
+    is_new_integration = _is_new_integration(path, base_ref)
 
     # Check 1: Actions in config but not in code
     for action_name in config_actions:
@@ -251,11 +286,19 @@ def check_config_sync(dir_path: str) -> int:
     if errors:
         for error in errors:
             print(f"❌ {error}")
-    if warnings:
+    if is_new_integration and warnings:
+        print("❌ New integrations must keep config.json input_schema in sync with code")
+        for warning in warnings:
+            print(f"❌ {warning}")
+    elif warnings:
+        if base_ref:
+            print("⚠️  Existing integration has config-code input drift; treating as historic warning")
+        else:
+            print("⚠️  Config-code input drift detected; pass --base-ref to fail this for new integrations")
         for warning in warnings:
             print(f"⚠️  {warning}")
 
-    if errors:
+    if errors or (is_new_integration and warnings):
         return 1
     return 0
 
@@ -277,6 +320,10 @@ Examples:
 """,
     )
     parser.add_argument(
+        "--base-ref",
+        help="Git ref to compare against; input drift fails only when config.json is new at this ref",
+    )
+    parser.add_argument(
         "dirs",
         nargs="+",
         metavar="dir",
@@ -291,7 +338,7 @@ Examples:
         print(f"Config sync: {dir_path}")
         print(f"{'=' * 60}")
 
-        result = check_config_sync(dir_path)
+        result = check_config_sync(dir_path, base_ref=args.base_ref)
         if result == 0:
             print("✅ Config and code are in sync")
         if result > exit_code:

--- a/scripts/check_config_sync.py
+++ b/scripts/check_config_sync.py
@@ -179,7 +179,38 @@ def _is_new_integration(dir_path: Path, base_ref: str | None) -> bool:
         capture_output=True,
         text=True,
     )
-    return result.returncode != 0
+    if result.returncode == 0:
+        return False
+
+    return not _is_renamed_integration_config(dir_path, base_ref)
+
+
+def _is_renamed_integration_config(dir_path: Path, base_ref: str) -> bool:
+    """Return True when config.json was renamed into this path since base_ref."""
+    config_path = _git_path(dir_path / "config.json")
+    result = subprocess.run(
+        ["git", "diff", "--name-status", "--find-renames", base_ref, "HEAD", "--", config_path],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return False
+
+    for line in result.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 3 and parts[0].startswith("R") and parts[2] == config_path:
+            return True
+    return False
+
+
+def _verify_base_ref(base_ref: str) -> bool:
+    """Return True when base_ref resolves to a commit."""
+    verify = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{base_ref}^{{commit}}"],
+        capture_output=True,
+        text=True,
+    )
+    return verify.returncode == 0
 
 
 def check_config_sync(dir_path: str, *, base_ref: str | None = None) -> int:
@@ -192,6 +223,10 @@ def check_config_sync(dir_path: str, *, base_ref: str | None = None) -> int:
     Returns:
         0 if in sync, 1 if mismatches found, 2 on errors.
     """
+    if base_ref and not _verify_base_ref(base_ref):
+        print(f"❌ base-ref '{base_ref}' not resolvable — check fetch-depth or ref name", file=sys.stderr)
+        return 2
+
     path = Path(dir_path)
     config_path = path / "config.json"
 

--- a/scripts/check_config_sync.py
+++ b/scripts/check_config_sync.py
@@ -151,45 +151,56 @@ def extract_actions_from_config(config: dict) -> dict[str, dict]:
     return actions
 
 
-def _git_path(path: Path) -> str:
-    """Return a repository-relative path for git object lookups when possible."""
+def _git_repo_root(path: Path) -> Path | None:
+    """Return the git repository root for path, if path is in a repository."""
     result = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
+        ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
         capture_output=True,
         text=True,
     )
     if result.returncode != 0:
-        return path.as_posix()
+        return None
 
-    repo_root = Path(result.stdout.strip()).resolve()
-    try:
-        return path.resolve().relative_to(repo_root).as_posix()
-    except ValueError:
-        return path.as_posix()
+    return Path(result.stdout.strip()).resolve()
 
 
-def _is_new_integration(dir_path: Path, base_ref: str | None) -> bool:
+def _git_path(path: Path, repo_root: Path) -> str:
+    """Return a repository-relative path for git object lookups."""
+    return path.resolve().relative_to(repo_root).as_posix()
+
+
+def _is_new_integration(dir_path: Path, base_ref: str | None, repo_root: Path | None) -> bool:
     """Return True when config.json did not exist at base_ref."""
-    if not base_ref:
+    if not base_ref or repo_root is None:
         return False
 
-    config_ref = f"{base_ref}:{_git_path(dir_path / 'config.json')}"
+    config_ref = f"{base_ref}:{_git_path(dir_path / 'config.json', repo_root)}"
     result = subprocess.run(
-        ["git", "cat-file", "-e", config_ref],
+        ["git", "-C", str(repo_root), "cat-file", "-e", config_ref],
         capture_output=True,
         text=True,
     )
     if result.returncode == 0:
         return False
 
-    return not _is_renamed_integration_config(dir_path, base_ref)
+    return not _is_renamed_integration_config(dir_path, base_ref, repo_root)
 
 
-def _is_renamed_integration_config(dir_path: Path, base_ref: str) -> bool:
+def _is_renamed_integration_config(dir_path: Path, base_ref: str, repo_root: Path) -> bool:
     """Return True when config.json was renamed into this path since base_ref."""
-    config_path = _git_path(dir_path / "config.json")
+    config_path = _git_path(dir_path / "config.json", repo_root)
     result = subprocess.run(
-        ["git", "diff", "--name-status", "--find-renames", base_ref, "HEAD", "--", config_path],
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "diff",
+            "--name-status",
+            "--find-renames",
+            "--diff-filter=R",
+            base_ref,
+            "HEAD",
+        ],
         capture_output=True,
         text=True,
     )
@@ -203,10 +214,10 @@ def _is_renamed_integration_config(dir_path: Path, base_ref: str) -> bool:
     return False
 
 
-def _verify_base_ref(base_ref: str) -> bool:
+def _verify_base_ref(base_ref: str, repo_root: Path) -> bool:
     """Return True when base_ref resolves to a commit."""
     verify = subprocess.run(
-        ["git", "rev-parse", "--verify", "--quiet", f"{base_ref}^{{commit}}"],
+        ["git", "-C", str(repo_root), "rev-parse", "--verify", "--quiet", f"{base_ref}^{{commit}}"],
         capture_output=True,
         text=True,
     )
@@ -223,10 +234,6 @@ def check_config_sync(dir_path: str, *, base_ref: str | None = None) -> int:
     Returns:
         0 if in sync, 1 if mismatches found, 2 on errors.
     """
-    if base_ref and not _verify_base_ref(base_ref):
-        print(f"❌ base-ref '{base_ref}' not resolvable — check fetch-depth or ref name", file=sys.stderr)
-        return 2
-
     path = Path(dir_path)
     config_path = path / "config.json"
 
@@ -251,6 +258,13 @@ def check_config_sync(dir_path: str, *, base_ref: str | None = None) -> int:
         print(f"Entry point not found: {entry_file}")
         return 2
 
+    repo_root = None
+    if base_ref:
+        repo_root = _git_repo_root(path)
+        if repo_root is None or not _verify_base_ref(base_ref, repo_root):
+            print(f"❌ base-ref '{base_ref}' not resolvable — check fetch-depth or ref name", file=sys.stderr)
+            return 2
+
     code_actions: dict[str, dict] = {}
     for pyfile in sorted(path.rglob("*.py")):
         file_actions = extract_actions_from_code(pyfile)
@@ -261,7 +275,7 @@ def check_config_sync(dir_path: str, *, base_ref: str | None = None) -> int:
 
     errors: list[str] = []
     warnings: list[str] = []
-    is_new_integration = _is_new_integration(path, base_ref)
+    is_new_integration = _is_new_integration(path, base_ref, repo_root)
 
     # Check 1: Actions in config but not in code
     for action_name in config_actions:

--- a/scripts/docs/check_code.md
+++ b/scripts/docs/check_code.md
@@ -17,7 +17,7 @@ This script performs ten sequential code quality checks on each given integratio
 9. **Config-code sync** — runs `check_config_sync.py` to verify config.json actions and input schemas match the code
 10. **Fetch pattern check** — runs `check_fetch_pattern.py` to flag SDK 2.x `context.fetch()` response handling issues
 
-When `--base-ref` is provided, the config-code sync step treats input-schema drift as fatal for brand-new integrations while preserving warning-only behaviour for integrations that already existed at the base ref.
+When `--base-ref` is provided, the config-code sync step treats input-schema drift as fatal for brand-new integrations while preserving warning-only behaviour for integrations that already existed at the base ref. The base ref must resolve locally; otherwise config-code sync exits with a processing error instead of classifying integrations as new.
 
 ## Usage
 
@@ -29,7 +29,7 @@ python scripts/check_code.py [--base-ref <ref>] <dir> [dir ...]
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `--base-ref` | No | Git ref used by config-code sync to fail input drift only for brand-new integrations |
+| `--base-ref` | No | Git ref used by config-code sync to fail input drift only for brand-new integrations. Must resolve locally. |
 | `dir` | Yes (one or more) | Path to an integration directory to check |
 
 ### Exit Codes

--- a/scripts/docs/check_code.md
+++ b/scripts/docs/check_code.md
@@ -37,8 +37,8 @@ python scripts/check_code.py [--base-ref <ref>] <dir> [dir ...]
 | Code | Meaning |
 |------|---------|
 | `0`  | All checks passed for all directories |
-| `1`  | One or more checks failed (includes nonexistent directories) |
-| `2`  | No directories provided (usage error) |
+| `1`  | One or more checks failed |
+| `2`  | Usage or processing error, including an unresolvable `--base-ref` reported by config-code sync |
 
 ### Examples
 
@@ -48,6 +48,9 @@ python scripts/check_code.py my-integration
 
 # Check multiple integrations
 python scripts/check_code.py my-integration another-api
+
+# Fail config/code input drift only for brand-new integrations compared with the base ref
+python scripts/check_code.py --base-ref origin/main my-integration
 
 # Combine with get_changed_dirs.py
 python scripts/check_code.py $(python scripts/get_changed_dirs.py origin/main)
@@ -220,7 +223,8 @@ check_config_sync.py [--base-ref <ref>] <dir>
 - Uses AST parsing to extract `@action` decorators and `inputs` access patterns from the entry point
 - Cross-validates action names and input parameters between `config.json` and code
 - Detects undocumented parameters, dead schema fields, and required/optional mismatches
-- With `--base-ref`, action mismatches always fail, while input drift fails only for integrations whose `config.json` did not exist at the base ref. Existing integrations keep input drift as warnings.
+- With `--base-ref`, action mismatches always fail, while input drift fails only for integrations whose `config.json` did not exist at the base ref. Existing integrations, including integrations renamed from an existing path, keep input drift as warnings.
+- If `--base-ref` cannot be resolved from the integration's git repository, the processing error is reported and `check_code.py` exits with code `2`.
 
 **On failure:**
 ```
@@ -351,7 +355,7 @@ Called by the `validate-integration.yml` workflow (on pull requests):
 ```yaml
 - name: Code Check
   if: steps.changed.outputs.dirs != ''
-  run: python scripts/check_code.py ${{ steps.changed.outputs.dirs }}
+  run: python scripts/check_code.py --base-ref origin/${{ github.base_ref }} ${{ steps.changed.outputs.dirs }}
 ```
 
 Also exercised by the `self-test.yml` workflow against test examples in `tests/examples/` as a regression guard.

--- a/scripts/docs/check_code.md
+++ b/scripts/docs/check_code.md
@@ -4,29 +4,32 @@ Runs code quality checks on one or more integration directories.
 
 ## Overview
 
-This script performs nine sequential code quality checks on each given integration directory:
+This script performs ten sequential code quality checks on each given integration directory:
 
-1. **Python syntax check** — uses `py_compile.compile()` directly to catch syntax errors
-2. **Import availability check** — imports `check_imports()` as a function to verify modules exist
-3. **JSON validity check** — uses `json.load()` directly to ensure all `.json` files are parseable
-4. **Lint check** — runs `ruff check` to catch code quality issues (undefined names, unused imports, style errors)
-5. **Format check** — runs `ruff format --check` to enforce consistent code formatting
-6. **Security scan** — runs `bandit` to flag hardcoded secrets, unsafe eval/exec, insecure HTTP calls
-7. **Dependency vulnerability scan** — runs `pip-audit` to check requirements.txt for packages with known CVEs
-8. **Config-code sync** — runs `check_config_sync.py` to verify config.json actions and input schemas match the code
+1. **Dependency installation** — installs `requirements.txt` so import checks can find third-party packages
+2. **Python syntax check** — uses `py_compile.compile()` directly to catch syntax errors
+3. **Import availability check** — imports `check_imports()` as a function to verify modules exist
+4. **JSON validity check** — uses `json.load()` directly to ensure all `.json` files are parseable
+5. **Lint check** — runs `ruff check` to catch code quality issues (undefined names, unused imports, style errors)
+6. **Format check** — runs `ruff format --check` to enforce consistent code formatting
+7. **Security scan** — runs `bandit` to flag hardcoded secrets, unsafe eval/exec, insecure HTTP calls
+8. **Dependency vulnerability scan** — runs `pip-audit` to check requirements.txt for packages with known CVEs
+9. **Config-code sync** — runs `check_config_sync.py` to verify config.json actions and input schemas match the code
+10. **Fetch pattern check** — runs `check_fetch_pattern.py` to flag SDK 2.x `context.fetch()` response handling issues
 
-Before running checks, it installs the integration's dependencies from `requirements.txt` so that import checks can find third-party packages.
+When `--base-ref` is provided, the config-code sync step treats input-schema drift as fatal for brand-new integrations while preserving warning-only behaviour for integrations that already existed at the base ref.
 
 ## Usage
 
 ```bash
-python scripts/check_code.py <dir> [dir ...]
+python scripts/check_code.py [--base-ref <ref>] <dir> [dir ...]
 ```
 
 ### Arguments
 
 | Argument | Required | Description |
 |----------|----------|-------------|
+| `--base-ref` | No | Git ref used by config-code sync to fail input drift only for brand-new integrations |
 | `dir` | Yes (one or more) | Path to an integration directory to check |
 
 ### Exit Codes
@@ -211,12 +214,13 @@ pip-audit -r <dir>/requirements.txt
 ### 9. Config-Code Sync Check
 
 ```bash
-check_config_sync.py <dir>
+check_config_sync.py [--base-ref <ref>] <dir>
 ```
 
 - Uses AST parsing to extract `@action` decorators and `inputs` access patterns from the entry point
 - Cross-validates action names and input parameters between `config.json` and code
 - Detects undocumented parameters, dead schema fields, and required/optional mismatches
+- With `--base-ref`, action mismatches always fail, while input drift fails only for integrations whose `config.json` did not exist at the base ref. Existing integrations keep input drift as warnings.
 
 **On failure:**
 ```
@@ -228,8 +232,17 @@ check_config_sync.py <dir>
    ❌ Config-code sync errors found
 
    Fix: Ensure config.json actions and input schemas match the code
-   Run locally: python scripts/check_config_sync.py <dir>
+   Run locally: python scripts/check_config_sync.py [--base-ref <ref>] <dir>
 ```
+
+### 10. Fetch Pattern Check
+
+```bash
+check_fetch_pattern.py <dir>
+```
+
+- Checks SDK 2.x integrations for old `context.fetch()` response-body access patterns
+- Ensures code uses `response.data` instead of treating the SDK 2.x fetch result as the raw body
 
 ## How It Works
 
@@ -269,7 +282,10 @@ flowchart TD
     Z -->|Yes| AA[Run config-code sync check]
     AA --> AB{Sync OK?}
     AB -->|No| H
-    AB -->|Yes| A
+    AB -->|Yes| AC[Run fetch pattern check]
+    AC --> AD{Fetch patterns OK?}
+    AD -->|No| H
+    AD -->|Yes| A
     A --> O{Any failures?}
     O -->|Yes| P[Exit 1]
     O -->|No| Q[Exit 0]
@@ -309,6 +325,9 @@ Checking: my-integration
 
 🔗 Checking config-code sync...
    ✅ Config-code sync OK
+
+🔄 Checking fetch patterns...
+   ✅ Fetch patterns OK
 
 ========================================
 ✅ CODE CHECK PASSED

--- a/scripts/docs/check_config_sync.md
+++ b/scripts/docs/check_config_sync.md
@@ -8,24 +8,27 @@ Config-code sync checker for Autohive integrations.
 
 This script validates that the `config.json` file and the integration's Python code are in sync. It scans all `.py` files in the integration directory (not just the entry point), supporting modular integrations where action handlers are split across multiple files. It uses AST (Abstract Syntax Tree) parsing to extract `@action` decorators and `inputs` access patterns from the code, then cross-validates them against the actions and input schemas declared in `config.json`.
 
+Action mismatches always fail. Input-schema drift is treated as historic baggage for integrations that already existed at the provided base ref, so those cases warn only. For brand-new integrations, the same input drift fails validation when `--base-ref` is provided.
+
 ## Usage
 
 ```bash
-python scripts/check_config_sync.py <dir> [dir ...]
+python scripts/check_config_sync.py [--base-ref <ref>] <dir> [dir ...]
 ```
 
 ### Arguments
 
 | Argument | Required | Description |
 |----------|----------|-------------|
+| `--base-ref` | No | Git ref used to decide whether each integration is new. If provided, input drift fails for integrations whose `config.json` did not exist at that ref. |
 | `dir` | Yes (one or more) | Path to an integration directory to check |
 
 ### Exit Codes
 
 | Code | Meaning |
 |------|---------|
-| `0`  | Config and code are in sync |
-| `1`  | One or more sync errors found |
+| `0`  | Config and code are in sync, or only existing-integration input drift warnings were found |
+| `1`  | One or more sync errors found, including input drift for a new integration when `--base-ref` is provided |
 | `2`  | An error occurred during processing (missing files, parse error, usage error) |
 
 ## Checks Performed
@@ -44,16 +47,18 @@ Verifies that every action declared in `config.json` has a corresponding `@actio
 Checks that every input parameter defined in the `config.json` schema for an action is actually accessed in the corresponding function's code.
 
 - Detects dead schema fields that are declared but never used
+- Warns for existing integrations; fails for new integrations when `--base-ref` is provided
 
 ### 3. Code Parameter Coverage
 
 Checks that every `inputs` key accessed in the code has a corresponding entry in the `config.json` schema.
 
 - Detects undocumented parameters that are used in code but missing from the config
+- Warns for existing integrations; fails for new integrations when `--base-ref` is provided
 
 ### 4. Required/Optional Consistency
 
-Validates that the required/optional status of parameters in `config.json` matches how they are accessed in the code (e.g., parameters accessed with `.get()` or default values should be optional).
+Validates that the required/optional status of parameters in `config.json` matches how they are accessed in the code (e.g., parameters accessed with `.get()` or default values should be optional). These mismatches warn for existing integrations and fail for new integrations when `--base-ref` is provided.
 
 ### 5. Action Name Matching
 
@@ -88,7 +93,8 @@ flowchart TD
 4. **Extract** `@action` decorator names and `inputs` key access patterns from the AST
 5. **Compare** actions between config and code — report any mismatches
 6. **Compare** input parameters for each action — report undocumented, dead, or mismatched fields
-7. **Report** all errors and warnings
+7. **If `--base-ref` was provided**, check whether the integration's `config.json` existed at that ref. Input drift is fatal for new integrations and warning-only for existing integrations.
+8. **Report** all errors and warnings
 
 ## Output Format
 
@@ -108,7 +114,7 @@ On failure:
    ❌ Config-code sync errors found
 
    Fix: Ensure config.json actions and input schemas match the code
-   Run locally: python scripts/check_config_sync.py <dir>
+   Run locally: python scripts/check_config_sync.py [--base-ref <ref>] <dir>
 ```
 
 ## Dependencies
@@ -119,10 +125,10 @@ No external dependencies are required. The script uses only Python's standard li
 
 ## Integration with CI
 
-This script is called by [`check_code.py`](check_code.md) as the final check step (step 9). It runs after all other quality checks have passed. It is also exercised independently by the `self-test.yml` workflow against test examples in `tests/examples/`.
+This script is called by [`check_code.py`](check_code.md) as part of the code check. In CI, the composite action passes the PR base ref through `check_code.py` so new integrations fail on input drift while existing integrations continue to warn. It is also exercised independently by the `self-test.yml` workflow against test examples in `tests/examples/`.
 
 ```python
 # Called internally by check_code.py:
 from check_config_sync import check_config_sync
-check_config_sync(str(dir_path))
+check_config_sync(str(dir_path), base_ref=base_ref)
 ```

--- a/scripts/docs/check_config_sync.md
+++ b/scripts/docs/check_config_sync.md
@@ -10,7 +10,7 @@ This script validates that the `config.json` file and the integration's Python c
 
 Action mismatches always fail. Input-schema drift is treated as historic baggage for integrations that already existed at the provided base ref, so those cases warn only. For brand-new integrations, the same input drift fails validation when `--base-ref` is provided.
 
-When `--base-ref` is provided, it must resolve to a local git commit. If the ref is missing because of a shallow checkout or an unfetched target branch, the script exits with code `2` instead of treating every integration as new. Renamed integration directories are detected with git rename detection for `config.json` and treated as existing integrations.
+When `--base-ref` is provided, it must resolve to a local git commit from the integration directory's git repository. If the ref is missing because of a shallow checkout or an unfetched target branch, the script exits with code `2` instead of treating every integration as new. Renamed integration directories are detected with git rename detection for `config.json` and treated as existing integrations.
 
 ## Usage
 
@@ -22,7 +22,7 @@ python scripts/check_config_sync.py [--base-ref <ref>] <dir> [dir ...]
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `--base-ref` | No | Git ref used to decide whether each integration is new. Must resolve locally. If provided, input drift fails for integrations whose `config.json` did not exist at that ref and was not renamed from an existing path. |
+| `--base-ref` | No | Git ref used to decide whether each integration is new. Must resolve locally from the integration directory's git repository. If provided, input drift fails for integrations whose `config.json` did not exist at that ref and was not renamed from an existing path. |
 | `dir` | Yes (one or more) | Path to an integration directory to check |
 
 ### Exit Codes
@@ -95,7 +95,7 @@ flowchart TD
 4. **Extract** `@action` decorator names and `inputs` key access patterns from the AST
 5. **Compare** actions between config and code — report any mismatches
 6. **Compare** input parameters for each action — report undocumented, dead, or mismatched fields
-7. **If `--base-ref` was provided**, verify the ref resolves, then check whether the integration's `config.json` existed at that ref or was renamed from an existing path. Input drift is fatal for new integrations and warning-only for existing integrations.
+7. **If `--base-ref` was provided**, resolve the integration's git repository root, verify the ref resolves there, then check whether the integration's `config.json` existed at that ref or was renamed from an existing path. Input drift is fatal for new integrations and warning-only for existing integrations.
 8. **Report** all errors and warnings
 
 ## Output Format

--- a/scripts/docs/check_config_sync.md
+++ b/scripts/docs/check_config_sync.md
@@ -10,6 +10,8 @@ This script validates that the `config.json` file and the integration's Python c
 
 Action mismatches always fail. Input-schema drift is treated as historic baggage for integrations that already existed at the provided base ref, so those cases warn only. For brand-new integrations, the same input drift fails validation when `--base-ref` is provided.
 
+When `--base-ref` is provided, it must resolve to a local git commit. If the ref is missing because of a shallow checkout or an unfetched target branch, the script exits with code `2` instead of treating every integration as new. Renamed integration directories are detected with git rename detection for `config.json` and treated as existing integrations.
+
 ## Usage
 
 ```bash
@@ -20,7 +22,7 @@ python scripts/check_config_sync.py [--base-ref <ref>] <dir> [dir ...]
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `--base-ref` | No | Git ref used to decide whether each integration is new. If provided, input drift fails for integrations whose `config.json` did not exist at that ref. |
+| `--base-ref` | No | Git ref used to decide whether each integration is new. Must resolve locally. If provided, input drift fails for integrations whose `config.json` did not exist at that ref and was not renamed from an existing path. |
 | `dir` | Yes (one or more) | Path to an integration directory to check |
 
 ### Exit Codes
@@ -29,7 +31,7 @@ python scripts/check_config_sync.py [--base-ref <ref>] <dir> [dir ...]
 |------|---------|
 | `0`  | Config and code are in sync, or only existing-integration input drift warnings were found |
 | `1`  | One or more sync errors found, including input drift for a new integration when `--base-ref` is provided |
-| `2`  | An error occurred during processing (missing files, parse error, usage error) |
+| `2`  | An error occurred during processing (missing files, parse error, usage error, unresolvable `--base-ref`) |
 
 ## Checks Performed
 
@@ -93,7 +95,7 @@ flowchart TD
 4. **Extract** `@action` decorator names and `inputs` key access patterns from the AST
 5. **Compare** actions between config and code — report any mismatches
 6. **Compare** input parameters for each action — report undocumented, dead, or mismatched fields
-7. **If `--base-ref` was provided**, check whether the integration's `config.json` existed at that ref. Input drift is fatal for new integrations and warning-only for existing integrations.
+7. **If `--base-ref` was provided**, verify the ref resolves, then check whether the integration's `config.json` existed at that ref or was renamed from an existing path. Input drift is fatal for new integrations and warning-only for existing integrations.
 8. **Report** all errors and warnings
 
 ## Output Format

--- a/tests/examples/input-drift/config.json
+++ b/tests/examples/input-drift/config.json
@@ -1,0 +1,38 @@
+{
+  "name": "input-drift",
+  "version": "1.0.0",
+  "description": "Test fixture with config/code input drift but matching actions",
+  "entry_point": "input_drift.py",
+  "actions": {
+    "get_data": {
+      "display_name": "Get Data",
+      "description": "Action defined in both config and code with input drift",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "description": "Limit"
+          },
+          "unused_param": {
+            "type": "string",
+            "description": "Defined in schema but never used in code"
+          },
+          "optional_direct": {
+            "type": "string",
+            "description": "Optional in schema but accessed directly"
+          },
+          "required_get": {
+            "type": "string",
+            "description": "Required in schema but accessed with get"
+          }
+        },
+        "required": ["limit", "required_get"]
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  }
+}

--- a/tests/examples/input-drift/input_drift.py
+++ b/tests/examples/input-drift/input_drift.py
@@ -1,0 +1,23 @@
+from typing import Any, Dict
+
+from autohive_integrations_sdk import ActionHandler, ActionResult, ExecutionContext, Integration
+
+app = Integration.load()
+
+
+@app.action("get_data")
+class GetDataAction(ActionHandler):
+    async def execute(self, inputs: Dict[str, Any], context: ExecutionContext):
+        limit = inputs["limit"]
+        optional_direct = inputs["optional_direct"]
+        required_get = inputs.get("required_get")
+        undocumented = inputs.get("undocumented_param")
+        return ActionResult(
+            data={
+                "limit": limit,
+                "optional_direct": optional_direct,
+                "required_get": required_get,
+                "undocumented": undocumented,
+            },
+            cost_usd=0.0,
+        )


### PR DESCRIPTION
## Summary

This changes config/code input drift from **warning-only** to **failure for brand-new integrations**, while preserving warning-only behavior for existing integrations.

## Key code changes

- `scripts/check_config_sync.py`
  - Adds `--base-ref <ref>`.
  - Verifies `--base-ref` resolves to a local commit before classifying integrations, returning exit code `2` for missing/unfetched refs.
  - Adds `_is_new_integration(...)` to detect whether `<integration>/config.json` existed at the base ref.
  - Handles renamed integration directories by using git rename detection for `config.json` and treating renamed integrations as existing.
  - Keeps action mismatches as hard failures for all integrations.
  - Converts input drift warnings into failures only when the integration is new at `--base-ref`.

- `scripts/check_code.py`
  - Adds `--base-ref <ref>`.
  - Passes the base ref into `check_config_sync(...)` during the code check step.

- `action.yml`
  - Passes the composite action's `base_ref` input into `scripts/check_code.py --base-ref ...`, so PR CI gets the new behavior automatically.

## Cases now enforced for new integrations

These still warn for existing integrations, but fail for new integrations:

- Parameter accessed in code but missing from `config.json` `input_schema`.
- Parameter defined in `input_schema` but never accessed in code.
- Parameter marked required in schema but accessed with `inputs.get(...)`.
- Parameter optional in schema but accessed directly with `inputs["param"]`.

## Tests and fixtures

- `.github/workflows/self-test.yml`
  - Adds coverage that input drift warns for existing integrations via `check_config_sync.py`.
  - Adds coverage that input drift fails for new integrations via `check_config_sync.py`.
  - Adds wrapper-layer coverage for both warn/fail behavior through `check_code.py --base-ref HEAD`.
  - Adds an invalid `--base-ref definitely-not-a-ref` regression expecting exit code `2`.

- `tests/examples/input-drift/`
  - New fixture covering all four input-drift cases while keeping action names in sync.

## Docs updated

- `README.md`
- `LOCAL_DEVELOPMENT.md`
- `scripts/docs/check_code.md`
- `scripts/docs/check_config_sync.md`

## Validation

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m py_compile scripts/check_config_sync.py scripts/check_code.py tests/examples/input-drift/input_drift.py`
- `.venv/bin/ruff check --config ruff.toml scripts/check_config_sync.py scripts/check_code.py tests/examples/input-drift/input_drift.py`
- `.venv/bin/ruff format --check --config ruff.toml scripts/check_config_sync.py scripts/check_code.py tests/examples/input-drift/input_drift.py`
- `.venv/bin/python scripts/check_code.py --base-ref HEAD tests/examples/good-integration`
- `.venv/bin/python scripts/check_code.py --base-ref HEAD tests/examples/input-drift`
- Verified new integration input drift fails via `check_code.py --base-ref HEAD tmp-input-drift`.
- Verified invalid base refs return exit code `2` from `check_config_sync.py`.