### PR TITLE
fix: follow helper input access in config sync

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -204,6 +204,9 @@ jobs:
           fi
           echo "✅ Invalid base ref correctly returns exit code 2"
 
+      - name: Test check_config_sync.py — focused pytest regressions
+        run: pytest tests/test_check_config_sync.py
+
       - name: Test check_code.py — input drift warns for existing integrations
         run: |
           OUTPUT=$(python scripts/check_code.py --base-ref HEAD tests/examples/input-drift 2>&1)

--- a/scripts/check_config_sync.py
+++ b/scripts/check_config_sync.py
@@ -63,6 +63,7 @@ def extract_actions_from_code(filepath: Path) -> dict[str, dict] | None:
         return None
 
     actions: dict[str, dict] = {}
+    module_helpers = _extract_module_helper_input_accesses(tree)
 
     for node in ast.walk(tree):
         if not isinstance(node, ast.ClassDef):
@@ -98,35 +99,110 @@ def extract_actions_from_code(filepath: Path) -> dict[str, dict] | None:
                 continue
 
             # Walk the execute method for inputs access
-            for subnode in ast.walk(item):
-                # inputs["key"]
-                if (
-                    isinstance(subnode, ast.Subscript)
-                    and isinstance(subnode.value, ast.Name)
-                    and subnode.value.id == "inputs"
-                    and isinstance(subnode.slice, ast.Constant)
-                    and isinstance(subnode.slice.value, str)
-                ):
-                    direct_params.add(subnode.slice.value)
+            method_accesses = _extract_named_input_accesses(item, {"inputs"})
+            direct_params.update(method_accesses["direct"])
+            get_params.update(method_accesses["get"])
 
-                # inputs.get("key") or inputs.get("key", default)
-                if (
-                    isinstance(subnode, ast.Call)
-                    and isinstance(subnode.func, ast.Attribute)
-                    and subnode.func.attr == "get"
-                    and isinstance(subnode.func.value, ast.Name)
-                    and subnode.func.value.id == "inputs"
-                    and subnode.args
-                    and isinstance(subnode.args[0], ast.Constant)
-                    and isinstance(subnode.args[0].value, str)
-                ):
-                    get_params.add(subnode.args[0].value)
+            # Include simple module-local helper calls that receive the action inputs.
+            # This intentionally avoids imported functions, method calls, dynamic calls,
+            # nested closures, and broader control-flow analysis.
+            for helper_accesses in _called_helper_accesses(item, module_helpers):
+                direct_params.update(helper_accesses["direct"])
+                get_params.update(helper_accesses["get"])
 
             break  # Only check the first execute method
 
         actions[action_name] = {"direct": direct_params, "get": get_params}
 
     return actions
+
+
+def _extract_named_input_accesses(node: ast.AST, input_names: set[str]) -> dict[str, set[str]]:
+    """Extract literal dict-key accesses for any local input variable name."""
+    direct_params: set[str] = set()
+    get_params: set[str] = set()
+
+    for subnode in ast.walk(node):
+        # inputs["key"]
+        if (
+            isinstance(subnode, ast.Subscript)
+            and isinstance(subnode.value, ast.Name)
+            and subnode.value.id in input_names
+            and isinstance(subnode.slice, ast.Constant)
+            and isinstance(subnode.slice.value, str)
+        ):
+            direct_params.add(subnode.slice.value)
+
+        # inputs.get("key") or inputs.get("key", default)
+        if (
+            isinstance(subnode, ast.Call)
+            and isinstance(subnode.func, ast.Attribute)
+            and subnode.func.attr == "get"
+            and isinstance(subnode.func.value, ast.Name)
+            and subnode.func.value.id in input_names
+            and subnode.args
+            and isinstance(subnode.args[0], ast.Constant)
+            and isinstance(subnode.args[0].value, str)
+        ):
+            get_params.add(subnode.args[0].value)
+
+    return {"direct": direct_params, "get": get_params}
+
+
+def _extract_module_helper_input_accesses(tree: ast.Module) -> dict[str, dict]:
+    """Return per-parameter input accesses for module-level helper functions."""
+    helpers: dict[str, dict] = {}
+
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+
+        params = [arg.arg for arg in node.args.args]
+        if not params:
+            continue
+
+        helpers[node.name] = {"params": params, "accesses": {}}
+        for param in params:
+            helpers[node.name]["accesses"][param] = _extract_named_input_accesses(node, {param})
+
+    return helpers
+
+
+def _called_helper_accesses(
+    node: ast.AST,
+    module_helpers: dict[str, dict],
+) -> list[dict[str, set[str]]]:
+    """Find module-local helper calls that pass the action's inputs object."""
+    accesses: list[dict[str, set[str]]] = []
+
+    for subnode in ast.walk(node):
+        if not isinstance(subnode, ast.Call):
+            continue
+        if not isinstance(subnode.func, ast.Name):
+            continue
+
+        helper = module_helpers.get(subnode.func.id)
+        if not helper:
+            continue
+
+        helper_accesses = helper["accesses"]
+        positional_params = helper["params"]
+        for index, arg in enumerate(subnode.args):
+            if not (isinstance(arg, ast.Name) and arg.id == "inputs"):
+                continue
+            if index >= len(positional_params):
+                continue
+            accesses.append(helper_accesses[positional_params[index]])
+
+        for keyword in subnode.keywords:
+            if keyword.arg is None:
+                continue
+            if not (isinstance(keyword.value, ast.Name) and keyword.value.id == "inputs"):
+                continue
+            if keyword.arg in helper_accesses:
+                accesses.append(helper_accesses[keyword.arg])
+
+    return accesses
 
 
 def extract_actions_from_config(config: dict) -> dict[str, dict]:

--- a/scripts/docs/check_config_sync.md
+++ b/scripts/docs/check_config_sync.md
@@ -8,6 +8,8 @@ Config-code sync checker for Autohive integrations.
 
 This script validates that the `config.json` file and the integration's Python code are in sync. It scans all `.py` files in the integration directory (not just the entry point), supporting modular integrations where action handlers are split across multiple files. It uses AST (Abstract Syntax Tree) parsing to extract `@action` decorators and `inputs` access patterns from the code, then cross-validates them against the actions and input schemas declared in `config.json`.
 
+Input access detection covers direct action method usage such as `inputs["key"]` and `inputs.get("key")`. It also follows simple module-local helper calls where an action passes its `inputs` object to a statically named helper, such as `_pagination_params(inputs)`, and attributes literal key accesses in that helper to the calling action. Imported functions, method calls, dynamic calls, nested closures, and broader control-flow analysis are intentionally out of scope.
+
 Action mismatches always fail. Input-schema drift is treated as historic baggage for integrations that already existed at the provided base ref, so those cases warn only. For brand-new integrations, the same input drift fails validation when `--base-ref` is provided.
 
 When `--base-ref` is provided, it must resolve to a local git commit from the integration directory's git repository. If the ref is missing because of a shallow checkout or an unfetched target branch, the script exits with code `2` instead of treating every integration as new. Renamed integration directories are detected with git rename detection for `config.json` and treated as existing integrations.
@@ -92,7 +94,7 @@ flowchart TD
 1. **Read** `config.json` and extract declared actions and their input schemas
 2. **Scan** all `.py` files in the integration directory (supporting modular layouts)
 3. **Parse** each file into an Abstract Syntax Tree (no code execution)
-4. **Extract** `@action` decorator names and `inputs` key access patterns from the AST
+4. **Extract** `@action` decorator names and direct or simple helper-based `inputs` key access patterns from the AST
 5. **Compare** actions between config and code — report any mismatches
 6. **Compare** input parameters for each action — report undocumented, dead, or mismatched fields
 7. **If `--base-ref` was provided**, resolve the integration's git repository root, verify the ref resolves there, then check whether the integration's `config.json` existed at that ref or was renamed from an existing path. Input drift is fatal for new integrations and warning-only for existing integrations.

--- a/tests/test_check_config_sync.py
+++ b/tests/test_check_config_sync.py
@@ -1,0 +1,140 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from check_config_sync import check_config_sync, extract_actions_from_code  # noqa: E402
+
+
+def _write_entry_point(tmp_path: Path, source: str) -> Path:
+    entry_point = tmp_path / "main.py"
+    entry_point.write_text(source, encoding="utf-8")
+    return entry_point
+
+
+def test_extract_actions_from_code_keeps_direct_inputs_get(tmp_path: Path) -> None:
+    entry_point = _write_entry_point(
+        tmp_path,
+        """
+app = None
+
+@app.action("get_data")
+class GetData:
+    def execute(self, inputs):
+        return inputs.get("foo")
+""",
+    )
+
+    actions = extract_actions_from_code(entry_point)
+
+    assert actions == {"get_data": {"direct": set(), "get": {"foo"}}}
+
+
+def test_extract_actions_from_code_includes_called_helper_input_accesses_only(tmp_path: Path) -> None:
+    entry_point = _write_entry_point(
+        tmp_path,
+        """
+app = None
+
+def _helper(action_inputs):
+    return {
+        "required": action_inputs["required_key"],
+        "optional": action_inputs.get("optional_key"),
+    }
+
+@app.action("calls_helper")
+class CallsHelper:
+    def execute(self, inputs):
+        return _helper(inputs)
+
+@app.action("does_not_call_helper")
+class DoesNotCallHelper:
+    def execute(self, inputs):
+        return inputs.get("local_key")
+""",
+    )
+
+    actions = extract_actions_from_code(entry_point)
+
+    assert actions == {
+        "calls_helper": {"direct": {"required_key"}, "get": {"optional_key"}},
+        "does_not_call_helper": {"direct": set(), "get": {"local_key"}},
+    }
+
+
+def test_extract_actions_from_code_includes_helper_keyword_input_accesses(tmp_path: Path) -> None:
+    entry_point = _write_entry_point(
+        tmp_path,
+        """
+app = None
+
+def _helper(action_inputs):
+    return action_inputs.get("optional_key")
+
+@app.action("calls_helper")
+class CallsHelper:
+    def execute(self, inputs):
+        return _helper(action_inputs=inputs)
+""",
+    )
+
+    actions = extract_actions_from_code(entry_point)
+
+    assert actions == {"calls_helper": {"direct": set(), "get": {"optional_key"}}}
+
+
+def test_check_config_sync_still_fails_new_integration_unused_schema_param(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
+    (tmp_path / "README.md").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=tmp_path, check=True)
+    base_ref = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    integration = tmp_path / "new-integration"
+    integration.mkdir()
+    (integration / "config.json").write_text(
+        json.dumps(
+            {
+                "entry_point": "main.py",
+                "actions": {
+                    "get_data": {
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {"unused_param": {"type": "string"}},
+                        }
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (integration / "main.py").write_text(
+        """
+app = None
+
+@app.action("get_data")
+class GetData:
+    def execute(self, inputs):
+        return {}
+""",
+        encoding="utf-8",
+    )
+
+    assert check_config_sync(str(integration), base_ref=base_ref) == 1
+    output = capsys.readouterr().out
+    assert "New integrations must keep config.json input_schema in sync with code" in output
+    assert "unused_param" in output


### PR DESCRIPTION
## Summary

Fixes a false positive in `check_config_sync.py` where schema parameters accessed through simple module-local helpers were reported as unused.

The checker now preserves direct `execute()` scanning and additionally follows statically named module-local helper calls when an action passes its `inputs` object, for patterns like `_pagination_params(inputs)`.

## Scope

- Supports helper parameter aliases such as `action_inputs`.
- Preserves direct vs `.get()` classification for required/optional consistency checks.
- Keeps analysis intentionally limited to module-local functions with static names.
- Does not analyze imported functions, method calls, dynamic calls, nested closures, or complex control flow.

## Tests

- Added focused pytest regressions for direct access, helper-only access, helper required/optional classification, non-calling action isolation, and new-integration fatal drift behavior.
- Wired the focused pytest regressions into the self-test workflow.
- Updated the config-sync docs to describe the limited helper-call support.

## Validation

- `.venv/bin/pytest tests/test_check_config_sync.py`
- `.venv/bin/ruff check scripts/check_config_sync.py tests/test_check_config_sync.py`
- `.venv/bin/ruff format --check scripts/check_config_sync.py tests/test_check_config_sync.py`
- From `autohive-integrations`: `.venv/bin/python ../autohive-integrations-tooling/scripts/check_code.py --base-ref origin/master missive`