### PR TITLE
fix: reject required custom auth fields

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -54,6 +54,9 @@ jobs:
           fi
           echo "✅ Auto-discovery correctly skips tests/"
 
+      - name: Test validate_integration.py — focused pytest regressions
+        run: pytest tests/test_validate_integration.py
+
       - name: Test check_imports.py — valid imports
         run: |
           python scripts/check_imports.py tests/examples/submodule-imports/valid_submodules.py

--- a/scripts/docs/validate_integration.md
+++ b/scripts/docs/validate_integration.md
@@ -107,7 +107,7 @@ Validates based on `auth.type`:
 | Auth Type | Required Fields | Description |
 |-----------|----------------|-------------|
 | `platform` | `provider`, `scopes` (array) | OAuth2-based authentication |
-| `custom` | `fields.properties` | API key or token-based authentication |
+| `custom` | `fields.properties` | API key or token-based authentication. `auth.fields.required` must be absent or empty; credential presence is handled by the platform connection flow. |
 | _(omitted)_ | — | No authentication (public APIs) |
 
 #### Action Configuration (`_validate_actions_config`)

--- a/scripts/validate_integration.py
+++ b/scripts/validate_integration.py
@@ -121,7 +121,10 @@ class IntegrationValidator:
         # use absolute imports like 'from <integration> import <instance>'.
         has_actions_dir = (self.path / 'actions').is_dir()
         if not (self.path / '__init__.py').exists() and not has_actions_dir:
-            self.add_warning("Missing __init__.py (required for package-style integrations, optional for modular integrations with actions/)")
+            self.add_warning(
+                "Missing __init__.py "
+                "(required for package-style integrations, optional for modular integrations with actions/)"
+            )
 
         # Check for forbidden files
         if (self.path / 'integration.py').exists():
@@ -244,6 +247,14 @@ class IntegrationValidator:
                 self.add_error("Custom auth requires 'fields' configuration")
             elif 'properties' not in auth.get('fields', {}):
                 self.add_error("Custom auth fields must have 'properties' defined")
+            else:
+                required_fields = auth['fields'].get('required')
+                if required_fields:
+                    self.add_error(
+                        "Custom auth fields must not define a non-empty auth.fields.required array. "
+                        "Credential collection and presence are handled by the platform connection flow; "
+                        "define auth.fields.properties only."
+                    )
 
         elif auth_type is not None:
             self.add_warning(f"Unknown auth type: '{auth_type}'. Expected 'platform' or 'custom'")

--- a/tests/examples/bad-icon/config.json
+++ b/tests/examples/bad-icon/config.json
@@ -15,8 +15,7 @@
           "label": "API Key",
           "help_text": "Enter your API key"
         }
-      },
-      "required": ["api_key"]
+      }
     }
   },
   "actions": {

--- a/tests/examples/good-integration/config.json
+++ b/tests/examples/good-integration/config.json
@@ -15,8 +15,7 @@
           "label": "API Key",
           "help_text": "Enter your API key"
         }
-      },
-      "required": ["api_key"]
+      }
     }
   },
   "actions": {

--- a/tests/examples/long-lines-integration/config.json
+++ b/tests/examples/long-lines-integration/config.json
@@ -15,8 +15,7 @@
           "label": "API Key",
           "help_text": "Enter your API key"
         }
-      },
-      "required": ["api_key"]
+      }
     }
   },
   "actions": {

--- a/tests/examples/modular-integration/config.json
+++ b/tests/examples/modular-integration/config.json
@@ -15,8 +15,7 @@
           "label": "API Key",
           "help_text": "Enter your API key"
         }
-      },
-      "required": ["api_key"]
+      }
     }
   },
   "actions": {

--- a/tests/sample-api/config.json
+++ b/tests/sample-api/config.json
@@ -15,8 +15,7 @@
           "label": "API Key",
           "help_text": "Enter your API key from the dashboard"
         }
-      },
-      "required": ["api_key"]
+      }
     }
   },
   "actions": {

--- a/tests/test_validate_integration.py
+++ b/tests/test_validate_integration.py
@@ -1,0 +1,78 @@
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from validate_integration import IntegrationValidator  # noqa: E402
+
+
+def _validate_auth(config: dict) -> IntegrationValidator:
+    validator = IntegrationValidator(Path("custom-auth"))
+    validator.config = config
+    validator._validate_auth_config()
+    return validator
+
+
+def test_custom_auth_without_required_is_valid() -> None:
+    validator = _validate_auth(
+        {
+            "auth": {
+                "type": "custom",
+                "fields": {
+                    "type": "object",
+                    "properties": {
+                        "api_key": {"type": "string"},
+                    },
+                },
+            }
+        }
+    )
+
+    assert validator.errors == []
+    assert validator.warnings == []
+
+
+def test_custom_auth_empty_required_array_is_allowed() -> None:
+    validator = _validate_auth(
+        {
+            "auth": {
+                "type": "custom",
+                "fields": {
+                    "type": "object",
+                    "properties": {
+                        "api_key": {"type": "string"},
+                    },
+                    "required": [],
+                },
+            }
+        }
+    )
+
+    assert validator.errors == []
+    assert validator.warnings == []
+
+
+def test_custom_auth_non_empty_required_array_is_rejected() -> None:
+    validator = _validate_auth(
+        {
+            "auth": {
+                "type": "custom",
+                "fields": {
+                    "type": "object",
+                    "properties": {
+                        "api_key": {"type": "string"},
+                    },
+                    "required": ["api_key"],
+                },
+            }
+        }
+    )
+
+    messages = [error.message for error in validator.errors]
+    assert messages == [
+        "Custom auth fields must not define a non-empty auth.fields.required array. "
+        "Credential collection and presence are handled by the platform connection flow; "
+        "define auth.fields.properties only."
+    ]
+    assert validator.warnings == []


### PR DESCRIPTION
## Summary

Implements Phase 1 of the PR #345 auth regression prevention plan.

Custom auth integrations now fail validation when `auth.fields.required` is present and non-empty. Credential collection and presence are handled by the platform connection flow, so integration configs should define `auth.fields.properties` only.

## Changes

- Adds a `validate_integration.py` guardrail for non-empty `custom` auth `fields.required`.
- Keeps absent `required` valid.
- Keeps empty `required: []` valid for now, matching the planned low-risk rollout.
- Updates tooling fixtures that are expected to validate successfully to remove non-empty custom auth `required` arrays.
- Adds focused pytest coverage for absent, empty, and non-empty custom auth `required` cases.
- Wires the new pytest regression file into the self-test workflow.
- Documents the custom-auth constraint in `scripts/docs/validate_integration.md`.

## Validation

- `.venv/bin/pytest tests/test_validate_integration.py`
- `.venv/bin/ruff check scripts/validate_integration.py tests/test_validate_integration.py`
- `.venv/bin/ruff format --check tests/test_validate_integration.py`
- `.venv/bin/python -m py_compile scripts/validate_integration.py tests/test_validate_integration.py`
- `.venv/bin/python scripts/validate_integration.py tests/examples/good-integration tests/examples/modular-integration tests/sample-api tests/examples/netlify`
- From `autohive-integrations`: `.venv/bin/python ../autohive-integrations-tooling/scripts/validate_integration.py active-campaign rss-reader-feedparser rss-reader-feedparser-ah-fetch`