### PR TITLE
fix: report skipped live integration tests

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Test validate_integration.py — focused pytest regressions
         run: pytest tests/test_validate_integration.py
 
+      - name: Test run_tests.py — focused pytest regressions
+        run: pytest tests/test_run_tests.py
+
       - name: Test check_imports.py — valid imports
         run: |
           python scripts/check_imports.py tests/examples/submodule-imports/valid_submodules.py

--- a/scripts/docs/run_tests.md
+++ b/scripts/docs/run_tests.md
@@ -6,7 +6,7 @@ Discovers and runs unit tests for integration directories, installing each integ
 
 Each integration pins its own SDK version in `requirements.txt`. The test runner installs dependencies and runs pytest **per-integration** to ensure each integration is tested against its own pinned SDK version.
 
-Integrations without `test_*_unit.py` files are skipped with a warning — they do not cause a failure.
+Integrations without `test_*_unit.py` files are skipped with a warning — they do not cause a failure. Live integration tests (`test_*_integration.py` files marked with `pytest.mark.integration`) are detected and reported, but are not run in CI.
 
 ## Usage
 
@@ -65,14 +65,15 @@ flowchart TD
 ### Step-by-Step
 
 1. Resolve integration directories from CLI args or auto-detect (subdirectories with `config.json`)
-2. For each directory, check for `test_*_unit.py` files in `tests/`
-3. Skip directories without unit tests (warn but don't fail)
-4. For each testable integration:
+2. For each directory, report any `pytest.mark.integration`-marked `test_*_integration.py` files detected in `tests/` and clearly state they are not run in CI
+3. For each directory, check for `test_*_unit.py` files in `tests/`
+4. Skip directories without unit tests (warn but don't fail)
+5. For each testable integration:
    a. Install the integration's `requirements.txt` (includes its pinned SDK version)
    b. Run pytest with `--import-mode=importlib`, `-m unit`, coverage enabled
    c. Record pass or failure
-5. Print summary of passed/failed integrations
-6. Exit 0 if all passed, 1 if any failed
+6. Print summary of passed/failed integrations
+7. Exit 0 if all passed, 1 if any failed
 
 ### Per-Integration Isolation
 
@@ -137,6 +138,7 @@ my-integration/
 This script only runs **unit tests** (`test_*_unit.py`). Integration tests (`test_*_integration.py`) are a separate concern:
 
 - They require real API credentials and must never run in CI.
+- When marked with `pytest.mark.integration` and detected, they are listed in the output with `Live integration tests: not run in CI` to avoid mistaking green unit-test CI for live API coverage.
 - They are not auto-discovered by pytest (`python_files` restricts discovery to `test_*_unit.py`).
 - Developers run them locally by passing the file path explicitly: `pytest <integration>/tests/test_*_integration.py -m integration`
 

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -56,6 +56,36 @@ def find_unit_test_files(integration_dir: Path) -> list[Path]:
     return sorted(tests_dir.glob("test_*_unit.py"))
 
 
+def find_live_integration_test_files(integration_dir: Path) -> list[Path]:
+    """Find all test_*_integration.py files in an integration's tests/ directory."""
+    tests_dir = integration_dir / "tests"
+    if not tests_dir.is_dir():
+        return []
+
+    live_test_files = []
+    for file in sorted(tests_dir.glob("test_*_integration.py")):
+        try:
+            content = file.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if "pytest.mark.integration" in content:
+            live_test_files.append(file)
+    return live_test_files
+
+
+def print_live_integration_test_notice(dirs: list[Path]) -> None:
+    """Report live integration tests that are intentionally not run by CI."""
+    live_test_files = [file for directory in dirs for file in find_live_integration_test_files(directory)]
+    if not live_test_files:
+        return
+
+    print("ℹ️  Live integration tests detected:")
+    for file in live_test_files:
+        print(f"   - {file}")
+    print("ℹ️  Live integration tests: not run in CI")
+    print()
+
+
 def get_integration_dirs(args: list[str]) -> list[Path]:
     """Resolve integration directories from CLI args or auto-detect."""
     if args:
@@ -138,7 +168,7 @@ def print_table(rows: list[tuple[str, str, str, str, str]], failed_outputs: dict
     """Print a formatted results table."""
     col_widths = [
         max(len(r[0]) for r in rows) + 2,
-        8,   # Tests
+        8,  # Tests
         10,  # Coverage
         14,  # Status
     ]
@@ -155,12 +185,7 @@ def print_table(rows: list[tuple[str, str, str, str, str]], failed_outputs: dict
     print(header)
     print(divider)
     for name, tests, coverage, status, _ in rows:
-        print(
-            f"{name:<{col_widths[0]}}"
-            f"{tests:>{col_widths[1]}}"
-            f"{coverage:>{col_widths[2]}}"
-            f"{status:>{col_widths[3]}}"
-        )
+        print(f"{name:<{col_widths[0]}}{tests:>{col_widths[1]}}{coverage:>{col_widths[2]}}{status:>{col_widths[3]}}")
     print(divider)
 
     # Total row
@@ -193,6 +218,8 @@ def main() -> int:
     if not dirs:
         print("⚠️  No integration directories found")
         return 0
+
+    print_live_integration_test_notice(dirs)
 
     # Collect which integrations have unit tests
     testable = []

--- a/tests/test_run_tests.py
+++ b/tests/test_run_tests.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from run_tests import find_live_integration_test_files, print_live_integration_test_notice  # noqa: E402
+
+
+def test_find_live_integration_test_files(tmp_path: Path) -> None:
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    live_test = tests_dir / "test_example_integration.py"
+    live_test.write_text("pytestmark = pytest.mark.integration\n", encoding="utf-8")
+    (tests_dir / "test_example_unit.py").write_text("", encoding="utf-8")
+    (tests_dir / "test_example.py").write_text("", encoding="utf-8")
+
+    assert find_live_integration_test_files(tmp_path) == [live_test]
+
+
+def test_print_live_integration_test_notice_lists_files(tmp_path: Path, capsys) -> None:
+    integration = tmp_path / "example"
+    tests_dir = integration / "tests"
+    tests_dir.mkdir(parents=True)
+    live_test = tests_dir / "test_example_integration.py"
+    live_test.write_text("pytestmark = pytest.mark.integration\n", encoding="utf-8")
+
+    print_live_integration_test_notice([integration])
+
+    output = capsys.readouterr().out
+    assert "Live integration tests detected" in output
+    assert str(live_test) in output
+    assert "Live integration tests: not run in CI" in output
+
+
+def test_print_live_notice_quiet_without_live_tests(tmp_path: Path, capsys) -> None:
+    integration = tmp_path / "example"
+    tests_dir = integration / "tests"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "test_example_unit.py").write_text("", encoding="utf-8")
+    (tests_dir / "test_legacy_integration.py").write_text("", encoding="utf-8")
+
+    print_live_integration_test_notice([integration])
+
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Summary

Improves CI/test output visibility so green unit-test CI is not mistaken for live API coverage.

`run_tests.py` now detects marked live integration test files and reports them before running unit tests:

```text
ℹ️  Live integration tests detected:
   - active-campaign/tests/test_active_campaign_integration.py
ℹ️  Live integration tests: not run in CI
```

## Details

- Detects `test_*_integration.py` files only when they include `pytest.mark.integration`, avoiding false positives from legacy unmarked files such as `test_good_integration.py`.
- Does not run live integration tests.
- Does not change pass/fail behavior; this is visibility-only.
- Adds focused pytest coverage and wires it into `self-test.yml`.
- Updates `scripts/docs/run_tests.md`.

## Validation

- `.venv/bin/pytest tests/test_run_tests.py`
- `.venv/bin/ruff check scripts/run_tests.py tests/test_run_tests.py`
- `.venv/bin/ruff format --check scripts/run_tests.py tests/test_run_tests.py`
- `.venv/bin/python -m py_compile scripts/run_tests.py tests/test_run_tests.py`
- `.venv/bin/python scripts/run_tests.py tests/examples/good-integration`
- From `autohive-integrations`: `.venv/bin/python ../autohive-integrations-tooling/scripts/run_tests.py active-campaign`